### PR TITLE
remove assert, need only return

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -706,7 +706,7 @@ class CocoaMQTTReader {
         // handle frame
         guard let frameType = CocoaMQTTFrameType(rawValue: UInt8(header & 0xF0)) else {
             printError("Abort! Received unknown frame type!")
-            return assert(false)
+            return
         }
         
         switch frameType {


### PR DESCRIPTION
As users face many crashes when through this line, better just return, no need to add `assert`
previously in 1.1.3 version, I don't see `assert` there and looks good, but the latest version somehow it added. https://github.com/emqx/CocoaMQTT/blob/1.1.3/Source/CocoaMQTT.swift#L654