### PR TITLE
Adding support for passing custom headers in the websocket upgrade request

### DIFF
--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "CocoaMQTT"
-  s.version     = "1.3.0-rc.1"
+  s.version     = "1.3.0-rc.2"
   s.summary     = "MQTT v3.1.1 client library for iOS and OS X written with Swift 5"
   s.homepage    = "https://github.com/emqx/CocoaMQTT"
   s.license     = { :type => "MIT" }

--- a/CocoaMQTTTests/CocoaMQTTTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTTests.swift
@@ -83,6 +83,48 @@ class CocoaMQTTTests: XCTestCase {
 
     }
     
+    // This is a basic test of the websocket authentication used by AWS IoT Custom Authorizers
+    // https://docs.aws.amazon.com/iot/latest/developerguide/custom-authorizer.html
+    func testWebsocketAuthConnect() {
+        return // Fix to have the test pass in case the AWS IoT endpoint has not been setup
+        let caller = Caller()
+        let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
+        websocket.headers = [
+            "x-amz-customauthorizer-name": "tokenAuthorizer",
+            "x-amz-customauthorizer-signature": "qnQ+T1i2ahSuispDMbjBPn/bN91jDpOmiRAVfTqfXTVvrEP6mNroYJLeVm6vrCp0dODgoiNYKWjwXANuseVafMALL18rMVyQOCaRTStI7xh/pFKVtnK+pdJroPto8ElJhia4cfETwmCdHq7rXLUqdvUGFiVh4+67M5R6088bfhZnjwjgcvhvG8mpTo2yONOkqDK9eA9XZcJhjrURF8DHsPrpIjIihYHq7LdsL5nFJ9FM11mA2AUj51fHZHO7uOfegprFgIeI32Tcn5KEWEDGrD3shvOrqUtDuodrfkALGtNjpGdWNOp/8XKK19KsbUJJrMaH6CDk3j6pn7S1lilz2Q==",
+            "token": "3c7a880d-0868-40dc-8183-8870323803fa",
+            "Sec-WebSocket-Protocol": "mqttv3.1",
+        ]
+        websocket.enableSSL = true
+        let mqtt = CocoaMQTT(clientID: clientID, host: "XXXXXXXXXXXX-ats.iot.eu-west-1.amazonaws.com", port: 443, socket: websocket)
+        mqtt.delegateQueue = deleQueue
+        mqtt.delegate = caller
+        mqtt.logLevel = .debug
+        mqtt.autoReconnect = false
+        _ = mqtt.connect()
+        wait_for { caller.isConnected }
+        XCTAssertEqual(mqtt.connState, .connected)
+        let topic = "d/AADDS"
+        mqtt.subscribe(topic)
+        wait_for {
+            if caller.subs.count >= 1 {
+                if caller.subs[0] == topic {
+                    return true
+                }
+            }
+            return false
+        }
+        mqtt.publish(topic, withString: "0", qos: .qos0, retained: false)
+        wait_for {
+            if caller.recvs.count >= 1 {
+                let f = caller.recvs[0]
+                XCTAssertEqual(f.topic, topic)
+                return true
+            }
+            return false
+        }
+    }
+    
     func testWebsocketConnect() {
         let caller = Caller()
         let websocket = CocoaMQTTWebSocket(uri: "/mqtt")

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you integrated by **CocoaPods**, you need to modify you `Podfile` like the fo
 use_frameworks!
 
 target 'Example' do
-    pod 'CocoaMQTT/WebSockets', '1.3.0'
+    pod 'CocoaMQTT/WebSockets', '1.3.0-rc.2'
 end
 
 ```
@@ -130,6 +130,22 @@ let mqtt = CocoaMQTT(clientID: clientID, host: host, port: 8083, socket: websock
 
 _ = mqtt.connect()
 
+```
+
+If you want to add additional custom header to the connection, you can use the following:
+
+```swift
+let websocket = CocoaMQTTWebSocket(uri: "/mqtt")
+websocket.headers = [
+            "x-api-key": "value"
+        ]
+        websocket.enableSSL = true
+
+let mqtt = CocoaMQTT(clientID: clientID, host: host, port: 8083, socket: websocket)
+
+// ...
+
+_ = mqtt.connect()
 ```
 
 ## Example App

--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -48,7 +48,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
     
     public var enableSSL = false
     
-    public var headers: [String: String]!
+    public var headers: [String: String] = [:]
 
     public typealias ConnectionBuilder = CocoaMQTTWebSocketConnectionBuilder
     

--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -38,8 +38,8 @@ public protocol CocoaMQTTWebSocketConnection: NSObjectProtocol {
 
 public protocol CocoaMQTTWebSocketConnectionBuilder {
     
-    func buildConnection(forURL url: URL) throws -> CocoaMQTTWebSocketConnection
-    
+    func buildConnection(forURL url: URL, withHeaders headers: [String: String]) throws -> CocoaMQTTWebSocketConnection
+
 }
 
 // MARK: - CocoaMQTTWebSocket
@@ -47,6 +47,8 @@ public protocol CocoaMQTTWebSocketConnectionBuilder {
 public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
     
     public var enableSSL = false
+    
+    public var headers: [String: String]!
 
     public typealias ConnectionBuilder = CocoaMQTTWebSocketConnectionBuilder
     
@@ -54,12 +56,15 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
         
         public init() {}
         
-        public func buildConnection(forURL url: URL) throws -> CocoaMQTTWebSocketConnection {
+        
+        public func buildConnection(forURL url: URL, withHeaders headers: [String: String]) throws -> CocoaMQTTWebSocketConnection {
             if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
                 let config = URLSessionConfiguration.default
+                config.httpAdditionalHeaders = headers
                 return CocoaMQTTWebSocket.FoundationConnection(url: url, config: config)
             } else {
-                let request = URLRequest(url: url)
+                var request = URLRequest(url: url)
+                headers.forEach { request.setValue($1, forHTTPHeaderField: $0)}
                 return CocoaMQTTWebSocket.StarscreamConnection(request: request)
             }
         }
@@ -90,7 +95,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
         try internalQueue.sync {
             connection?.disconnect()
             connection?.delegate = nil
-            let newConnection = try builder.buildConnection(forURL: url)
+            let newConnection = try builder.buildConnection(forURL: url, withHeaders: self.headers)
             connection = newConnection
             newConnection.delegate = self
             newConnection.queue = internalQueue


### PR DESCRIPTION
With this PR I have added support to pass custom headers in the Websocket upgrade request in order to support to  custom authorizers for AWS IoT