### PR TITLE
Remove NS prefix from ProcessInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you're building for iOS, tvOS:
 Create a client to connect MQTT Broker:
 
 ```swift
-let clientID = "CocoaMQTT-" + String(NSProcessInfo().processIdentifier)
+let clientID = "CocoaMQTT-" + String(ProcessInfo().processIdentifier)
 let mqtt = CocoaMQTT(clientID: clientID, host: "localhost", port: 1883)
 mqtt.username = "test"
 mqtt.password = "public"


### PR DESCRIPTION
Removed a NS prefix from example with accordance to [Swift Evolution no. 86](https://github.com/apple/swift-evolution/blob/master/proposals/0086-drop-foundation-ns.md).