### PR TITLE
Fix typos in project

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -235,7 +235,7 @@ extension ViewController {
         }
         
         if fun == "mqttDidDisconnect(_:withError:)" {
-            prettyName = "didDisconect"
+            prettyName = "didDisconnect"
         }
 
         print("[TRACE] [\(prettyName)]: \(message)")
@@ -243,10 +243,10 @@ extension ViewController {
 }
 
 extension Optional {
-    // Unwarp optional value for printing log only
+    // Unwrap optional value for printing log only
     var description: String {
-        if let warped = self {
-            return "\(warped)"
+        if let self = self {
+            return "\(self)"
         }
         return ""
     }

--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -157,7 +157,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// - TODO: What's behavior each Clean Session flags???
     public var cleanSession = true
     
-    /// Setup a **Last Will Message** to client before connecting to borker
+    /// Setup a **Last Will Message** to client before connecting to broker
     public var willMessage: CocoaMQTTMessage?
     
     /// Enable backgounding socket if running on iOS platform. Default is true
@@ -170,7 +170,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     
     /// Delegate Executed queue. Default is `DispatchQueue.main`
     ///
-    /// The delegate/closure callback function will be commited asynchronously to it
+    /// The delegate/closure callback function will be committed asynchronously to it
     public var delegateQueue = DispatchQueue.main
     
     public var connState = CocoaMQTTConnState.disconnected {
@@ -224,7 +224,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// After that, it uses this value for subsequent requests.
     public var maxAutoReconnectTimeInterval: UInt16 = 128 // 128 seconds
     
-    private var reconectTimeInterval: UInt16 = 0
+    private var reconnectTimeInterval: UInt16 = 0
     
     private var autoReconnTimer: CocoaMQTTTimer?
     private var is_internal_disconnected = false
@@ -390,7 +390,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     /// Send a DISCONNECT packet to the broker then close the connection
     ///
     /// - Note: Only can be called from outside.
-    ///         If you want to disconnect from inside framwork, call internal_disconnect()
+    ///         If you want to disconnect from inside framework, call internal_disconnect()
     ///         disconnect expectedly
     public func disconnect() {
         is_internal_disconnected = false
@@ -515,7 +515,7 @@ extension CocoaMQTT: CocoaMQTTDeliverProtocol {
         if let publish = frame as? FramePublish {
             let msgid = publish.msgid
             guard let message = sendingMessages[msgid] else {
-                printError("Want send \(frame), but not found in CoacoaMQTT cache")
+                printError("Want send \(frame), but not found in CocoaMQTT cache")
                 return
             }
             
@@ -599,18 +599,18 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
             return
         }
         
-        if reconectTimeInterval == 0 {
-            reconectTimeInterval = autoReconnectTimeInterval
+        if reconnectTimeInterval == 0 {
+            reconnectTimeInterval = autoReconnectTimeInterval
         }
         
-        // Start reconnector once socket error occuried
-        printInfo("Try reconnect to server after \(reconectTimeInterval)s")
-        autoReconnTimer = CocoaMQTTTimer.after(Double(reconectTimeInterval), name: "autoReconnTimer", { [weak self] in
+        // Start reconnector once socket error occurred
+        printInfo("Try reconnect to server after \(reconnectTimeInterval)s")
+        autoReconnTimer = CocoaMQTTTimer.after(Double(reconnectTimeInterval), name: "autoReconnTimer", { [weak self] in
             guard let self = self else { return }
-            if self.reconectTimeInterval < self.maxAutoReconnectTimeInterval {
-                self.reconectTimeInterval *= 2
+            if self.reconnectTimeInterval < self.maxAutoReconnectTimeInterval {
+                self.reconnectTimeInterval *= 2
             } else {
-                self.reconectTimeInterval = self.maxAutoReconnectTimeInterval
+                self.reconnectTimeInterval = self.maxAutoReconnectTimeInterval
             }
             _ = self.connect()
         })
@@ -620,14 +620,14 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
 // MARK: - CocoaMQTTReaderDelegate
 extension CocoaMQTT: CocoaMQTTReaderDelegate {
     
-    func didRecevied(_ reader: CocoaMQTTReader, connack: FrameConnAck) {
+    func didReceive(_ reader: CocoaMQTTReader, connack: FrameConnAck) {
         printDebug("RECV: \(connack)")
 
         if connack.returnCode == .accept {
             
             // Disable auto-reconnect
             
-            reconectTimeInterval = 0
+            reconnectTimeInterval = 0
             autoReconnTimer = nil
             is_internal_disconnected = false
             
@@ -669,14 +669,14 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         didConnectAck(self, connack.returnCode)
     }
 
-    func didRecevied(_ reader: CocoaMQTTReader, publish: FramePublish) {
+    func didReceive(_ reader: CocoaMQTTReader, publish: FramePublish) {
         printDebug("RECV: \(publish)")
         
         let message = CocoaMQTTMessage(topic: publish.topic, payload: publish.payload(), qos: publish.qos, retained: publish.retained)
         
         message.duplicated = publish.dup
         
-        printInfo("Recevied message: \(message)")
+        printInfo("Received message: \(message)")
         delegate?.mqtt(self, didReceiveMessage: message, id: publish.msgid)
         didReceiveMessage(self, message, publish.msgid)
         
@@ -687,7 +687,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         }
     }
 
-    func didReceived(_ reader: CocoaMQTTReader, puback: FramePubAck) {
+    func didReceive(_ reader: CocoaMQTTReader, puback: FramePubAck) {
         printDebug("RECV: \(puback)")
         
         deliver.ack(by: puback)
@@ -696,19 +696,19 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         didPublishAck(self, puback.msgid)
     }
     
-    func didRecevied(_ reader: CocoaMQTTReader, pubrec: FramePubRec) {
+    func didReceive(_ reader: CocoaMQTTReader, pubrec: FramePubRec) {
         printDebug("RECV: \(pubrec)")
         
         deliver.ack(by: pubrec)
     }
 
-    func didReceived(_ reader: CocoaMQTTReader, pubrel: FramePubRel) {
+    func didReceive(_ reader: CocoaMQTTReader, pubrel: FramePubRel) {
         printDebug("RECV: \(pubrel)")
 
         puback(FrameType.pubcomp, msgid: pubrel.msgid)
     }
 
-    func didRecevied(_ reader: CocoaMQTTReader, pubcomp: FramePubComp) {
+    func didReceive(_ reader: CocoaMQTTReader, pubcomp: FramePubComp) {
         printDebug("RECV: \(pubcomp)")
 
         deliver.ack(by: pubcomp)
@@ -717,7 +717,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         didCompletePublish(self, pubcomp.msgid)
     }
 
-    func didReceived(_ reader: CocoaMQTTReader, suback: FrameSubAck) {
+    func didReceive(_ reader: CocoaMQTTReader, suback: FrameSubAck) {
         printDebug("RECV: \(suback)")
         
         guard let topicsAndQos = subscriptionsWaitingAck.removeValue(forKey: suback.msgid) else {
@@ -745,7 +745,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         didSubscribeTopics(self, success, failed)
     }
 
-    func didReceived(_ reader: CocoaMQTTReader, unsuback: FrameUnsubAck) {
+    func didReceive(_ reader: CocoaMQTTReader, unsuback: FrameUnsubAck) {
         printDebug("RECV: \(unsuback)")
         
         guard let topics = unsubscriptionsWaitingAck.removeValue(forKey: unsuback.msgid) else {
@@ -760,7 +760,7 @@ extension CocoaMQTT: CocoaMQTTReaderDelegate {
         didUnsubscribeTopics(self, topics)
     }
 
-    func didReceived(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
+    func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp) {
         printDebug("RECV: \(pingresp)")
         
         delegate?.mqttDidReceivePong(self)

--- a/Source/CocoaMQTTDeliver.swift
+++ b/Source/CocoaMQTTDeliver.swift
@@ -88,7 +88,7 @@ class CocoaMQTTDeliver: NSObject {
                 mqueue.append(f)
             }
             self.storage = storage
-            printInfo("Deliver recvoer \(frames.count) msgs")
+            printInfo("Deliver recover \(frames.count) msgs")
             printDebug("Recover message \(frames)")
         }
         
@@ -200,7 +200,7 @@ extension CocoaMQTTDeliver {
         }
     }
     
-    /// Attemp to redliver in-flight messages
+    /// Attempt to redeliver in-flight messages
     private func redeliver() {
         if isInflightEmpty {
             // Revoke the awaiting timer

--- a/Source/CocoaMQTTMessage.swift
+++ b/Source/CocoaMQTTMessage.swift
@@ -25,7 +25,7 @@ public class CocoaMQTTMessage: NSObject {
     /// - note: Readonly property
     public var duplicated = false
     
-    /// Return the payload as a utf8 string if possiable
+    /// Return the payload as a utf8 string if possible
     ///
     /// It will return nil if the payload is not a valid utf8 string
     public var string: String? {

--- a/Source/CocoaMQTTReader.swift
+++ b/Source/CocoaMQTTReader.swift
@@ -18,23 +18,23 @@ enum CocoaMQTTReadTag: Int {
 ///
 protocol CocoaMQTTReaderDelegate: AnyObject {
    
-    func didRecevied(_ reader: CocoaMQTTReader, connack: FrameConnAck)
+    func didReceive(_ reader: CocoaMQTTReader, connack: FrameConnAck)
     
-    func didRecevied(_ reader: CocoaMQTTReader, publish: FramePublish)
+    func didReceive(_ reader: CocoaMQTTReader, publish: FramePublish)
     
-    func didReceived(_ reader: CocoaMQTTReader, puback: FramePubAck)
+    func didReceive(_ reader: CocoaMQTTReader, puback: FramePubAck)
     
-    func didRecevied(_ reader: CocoaMQTTReader, pubrec: FramePubRec)
+    func didReceive(_ reader: CocoaMQTTReader, pubrec: FramePubRec)
     
-    func didReceived(_ reader: CocoaMQTTReader, pubrel: FramePubRel)
+    func didReceive(_ reader: CocoaMQTTReader, pubrel: FramePubRel)
     
-    func didRecevied(_ reader: CocoaMQTTReader, pubcomp: FramePubComp)
+    func didReceive(_ reader: CocoaMQTTReader, pubcomp: FramePubComp)
     
-    func didReceived(_ reader: CocoaMQTTReader, suback: FrameSubAck)
+    func didReceive(_ reader: CocoaMQTTReader, suback: FrameSubAck)
     
-    func didReceived(_ reader: CocoaMQTTReader, unsuback: FrameUnsubAck)
+    func didReceive(_ reader: CocoaMQTTReader, unsuback: FrameUnsubAck)
     
-    func didReceived(_ reader: CocoaMQTTReader, pingresp: FramePingResp)
+    func didReceive(_ reader: CocoaMQTTReader, pingresp: FramePingResp)
 }
 
 class CocoaMQTTReader {
@@ -117,55 +117,55 @@ class CocoaMQTTReader {
                 printError("Reader parse \(frameType) failed, data: \(data)")
                 break
             }
-            delegate?.didRecevied(self, connack: connack)
+            delegate?.didReceive(self, connack: connack)
         case .publish:
             guard let publish = FramePublish(fixedHeader: header, bytes: data) else {
                 printError("Reader parse \(frameType) failed, data: \(data)")
                 break
             }
-            delegate?.didRecevied(self, publish: publish)
+            delegate?.didReceive(self, publish: publish)
         case .puback:
             guard let puback = FramePubAck(fixedHeader: header, bytes: data) else {
                 printError("Reader parse \(frameType) failed, data: \(data)")
                 break
             }
-            delegate?.didReceived(self, puback: puback)
+            delegate?.didReceive(self, puback: puback)
         case .pubrec:
             guard let pubrec = FramePubRec(fixedHeader: header, bytes: data) else {
                 printError("Reader parse \(frameType) failed, data: \(data)")
                 break
             }
-            delegate?.didRecevied(self, pubrec: pubrec)
+            delegate?.didReceive(self, pubrec: pubrec)
         case .pubrel:
             guard let pubrel = FramePubRel(fixedHeader: header, bytes: data) else {
                 printError("Reader parse \(frameType) failed, data: \(data)")
                 break
             }
-            delegate?.didReceived(self, pubrel: pubrel)
+            delegate?.didReceive(self, pubrel: pubrel)
         case .pubcomp:
             guard let pubcomp = FramePubComp(fixedHeader: header, bytes: data) else {
                 printError("Reader parse \(frameType) failed, data: \(data)")
                 break
             }
-            delegate?.didRecevied(self, pubcomp: pubcomp)
+            delegate?.didReceive(self, pubcomp: pubcomp)
         case .suback:
             guard let frame = FrameSubAck(fixedHeader: header, bytes: data) else {
                 printError("Reader parse \(frameType) failed, data: \(data)")
                 break
             }
-            delegate?.didReceived(self, suback: frame)
+            delegate?.didReceive(self, suback: frame)
         case .unsuback:
             guard let frame = FrameUnsubAck(fixedHeader: header, bytes: data) else {
                 printError("Reader parse \(frameType) failed, data: \(data)")
                 break
             }
-            delegate?.didReceived(self, unsuback: frame)
+            delegate?.didReceive(self, unsuback: frame)
         case .pingresp:
             guard let frame = FramePingResp(fixedHeader: header, bytes: data) else {
                 printError("Reader parse \(frameType) failed, data: \(data)")
                 break
             }
-            delegate?.didReceived(self, pingresp: frame)
+            delegate?.didReceive(self, pingresp: frame)
         default:
             break
         }

--- a/Source/CocoaMQTTStorage.swift
+++ b/Source/CocoaMQTTStorage.swift
@@ -97,7 +97,7 @@ final class CocoaMQTTStorage: CocoaMQTTStorageProtocol {
     }
     
     private func parse(_ bytes: [UInt8]) -> (UInt8, [UInt8])? {
-        /// bytes 1..<5 may be 'Remaing Length'
+        /// bytes 1..<5 may be 'Remaining Length'
         for i in 1 ..< 5 {
             if (bytes[i] & 0x80) == 0 {
                 return (bytes[0], Array(bytes.suffix(from: i+1)))

--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -59,7 +59,6 @@ extension UInt8 {
 }
 
 public enum CocoaMQTTError: Error {
-    case invalidFrameStructrue
     case invalidURL
     case readTimeout
     case writeTimeout

--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -411,12 +411,12 @@ extension CocoaMQTTWebSocket.StarscreamConnection: SSLTrustValidator {
         guard let delegate = self.delegate else { return false }
         
         var shouldAccept = false
-        let semephore = DispatchSemaphore(value: 0)
+        let semaphore = DispatchSemaphore(value: 0)
         delegate.connection(self, didReceive: trust) { result in
             shouldAccept = result
-            semephore.signal()
+            semaphore.signal()
         }
-        semephore.wait()
+        semaphore.wait()
         
         return shouldAccept
     }


### PR DESCRIPTION
This PR addresses the typos throughout the project.

The most notable changes are 
- removed an unused `invalidFrameStructrue` case from `CocoaMQTTError` enum (and thus a typo)
- renamed protocol methods in `CocoaMQTTReaderDelegate` from to `didRecevied`, `didReceived` to `didReceive`