### PR TITLE
Fix redeliver Timer error

### DIFF
--- a/Source/CocoaMQTTDeliver.swift
+++ b/Source/CocoaMQTTDeliver.swift
@@ -23,13 +23,16 @@ private struct InflightFrame {
     
     var timestamp: TimeInterval
     
+    var retryCount: Int
+
     init(frame: Frame) {
-        self.init(frame: frame, timestamp: Date.init(timeIntervalSinceNow: 0).timeIntervalSince1970)
+        self.init(frame: frame, timestamp: Date.init(timeIntervalSinceNow: 0).timeIntervalSince1970, retryCount: 0)
     }
     
-    init(frame: Frame, timestamp: TimeInterval) {
+    init(frame: Frame, timestamp: TimeInterval, retryCount: Int) {
         self.frame = frame
         self.timestamp = timestamp
+        self.retryCount = retryCount
     }
 }
 
@@ -210,11 +213,11 @@ extension CocoaMQTTDeliver {
         
         let nowTimestamp = Date(timeIntervalSinceNow: 0).timeIntervalSince1970
         for (idx, frame) in inflight.enumerated() {
-            if (nowTimestamp - frame.timestamp) >= (retryTimeInterval/1000.0) {
+            if (nowTimestamp - frame.timestamp) >= (retryTimeInterval/1000.0) * Double(frame.retryCount) {
                 
                 var duplicatedFrame = frame
                 duplicatedFrame.frame.dup = true
-                duplicatedFrame.timestamp = nowTimestamp
+                duplicatedFrame.retryCount += 1
                 
                 inflight[idx] = duplicatedFrame
                 


### PR DESCRIPTION
### 修复重新发送计时器错误

#### 错误描述

在 Re-delivery frame 时，对 frame 的 timestamp 进行了重新赋值，但程序运行需要消耗时间，导致会出现几毫秒的误差，于是在定时器下一次被触发时，nowTimestamp - frame.timestamp 比 (retryTimeInterval/1000.0) 小几毫秒，导致多数情况下定时器每执行两次才会触发一次 Re-delivery frame 逻辑，误差测试如下：
![image](https://user-images.githubusercontent.com/17736408/101331363-d8575880-38ae-11eb-9e09-5ba6bedb589c.png)

#### 修复方案

为 Frame 增加一个重试次数（retryCount）变量，在 redeliver 方法中，比较 时间差值（nowTimestamp - frame.timestamp） 与 重试时间*重试次数（(retryTimeInterval/1000.0) * frame.retryCount）的大小，即：
``` swift
if (nowTimestamp - frame.timestamp) >= (retryTimeInterval/1000.0) * Double(frame.retryCount) {}
```

#### 说明

以上是我能想到的处理方案，如果有更好的处理方式，欢迎回复我。