### PR TITLE
Fix compile error "Enum cases with associated values cannot be marked potentially unavailable with '@available'"

### DIFF
--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -59,12 +59,15 @@ extension UInt8 {
 }
 
 public enum CocoaMQTTError: Error {
+
+    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    enum FoundationConnection : Error {
+        case closed(URLSessionWebSocketTask.CloseCode)
+    }
+
     case invalidURL
     case readTimeout
     case writeTimeout
-    
-    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    case closed(URLSessionWebSocketTask.CloseCode)
 }
 
 extension Array where Element == UInt8 {

--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -59,7 +59,6 @@ extension UInt8 {
 }
 
 public enum CocoaMQTTError: Error {
-
     @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     enum FoundationConnection : Error {
         case closed(URLSessionWebSocketTask.CloseCode)

--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -60,7 +60,7 @@ extension UInt8 {
 
 public enum CocoaMQTTError: Error {
     @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    enum FoundationConnection : Error {
+    enum FoundationConnection: Error {
         case closed(URLSessionWebSocketTask.CloseCode)
     }
 

--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -368,7 +368,7 @@ extension CocoaMQTTWebSocket.FoundationConnection: URLSessionWebSocketDelegate {
 
     public func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
         queue.async {
-            self.delegate?.connectionClosed(self, withError: CocoaMQTTError.closed(closeCode))
+            self.delegate?.connectionClosed(self, withError: CocoaMQTTError.FoundationConnection.closed(closeCode))
         }
     }
 }


### PR DESCRIPTION
As far I understood the problem we have two possible solutions:
- Either need to mark the whole enum as @available(iOS 13.0, *) 
- Or need to increase your deployment target to iOS 13.0

Last one is not want we want to do for this library. First one could be achieved with "Nested Enums" (At least I think so).
This is want I did in this pull request. Want do you think? Feedback highly welcome. 🤗 

For info about "Nested Enums" see https://developerinsider.co/advanced-enum-enumerations-by-example-swift-programming-language/
