### PR TITLE
update Starscream to 3.1.1 to fix carthage build error

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "robbiehanson/CocoaAsyncSocket" "7.6.3"
-github "daltoniam/Starscream" "3.0.2"
+github "daltoniam/Starscream" "3.1.1"


### PR DESCRIPTION
Starscream in SPM updated to 3.1.1. but it's still 3.0.2 in Carthage and caused build error. Update it to 3.1.1