### PR TITLE
Set FoundationConnection enum to public

### DIFF
--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -60,7 +60,7 @@ extension UInt8 {
 
 public enum CocoaMQTTError: Error {
     @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    enum FoundationConnection: Error {
+    public enum FoundationConnection: Error {
         case closed(URLSessionWebSocketTask.CloseCode)
     }
 


### PR DESCRIPTION
This fixes the 'FoundationConnection' is inaccessible due to 'internal' protection level error on Xcode 13