### PR TITLE
Migrate to Xcode 13

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "robbiehanson/CocoaAsyncSocket" "7.6.3"
+github "robbiehanson/CocoaAsyncSocket" "7.6.5"
 github "daltoniam/Starscream" "3.1.1"

--- a/CocoaMQTT.xcodeproj/project.pbxproj
+++ b/CocoaMQTT.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -59,12 +59,18 @@
 		111124CE24BB516300E2DFBC /* FramePubComp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D43DE5522FAEDDA00D9A06B /* FramePubComp.swift */; };
 		111124CF24BB516300E2DFBC /* CocoaMQTTTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82519C0622ACC6E100FA0815 /* CocoaMQTTTypes.swift */; };
 		111124D024BB516300E2DFBC /* FrameConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D43DE4B22FAEB8B00D9A06B /* FrameConnect.swift */; };
-		11EBF5F524BB537A0096E199 /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11EBF5F324BB537A0096E199 /* CocoaAsyncSocket.framework */; };
-		11EBF5F624BB537A0096E199 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11EBF5F424BB537A0096E199 /* Starscream.framework */; };
-		11EBF5F924BB53A00096E199 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11EBF5F724BB53A00096E199 /* Starscream.framework */; };
-		11EBF5FA24BB53A00096E199 /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11EBF5F824BB53A00096E199 /* CocoaAsyncSocket.framework */; };
-		11EBF5FD24BB53BC0096E199 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11EBF5FB24BB53BC0096E199 /* Starscream.framework */; };
-		11EBF5FE24BB53BC0096E199 /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11EBF5FC24BB53BC0096E199 /* CocoaAsyncSocket.framework */; };
+		4A26DBF12714541E004C251B /* CocoaAsyncSocket.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A26DBF02714541E004C251B /* CocoaAsyncSocket.xcframework */; };
+		4A26DBF22714541E004C251B /* CocoaAsyncSocket.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4A26DBF02714541E004C251B /* CocoaAsyncSocket.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4A26DBF42714542A004C251B /* CocoaAsyncSocket.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A26DBF02714541E004C251B /* CocoaAsyncSocket.xcframework */; };
+		4A26DBF52714542A004C251B /* CocoaAsyncSocket.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4A26DBF02714541E004C251B /* CocoaAsyncSocket.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4A26DBF727145435004C251B /* CocoaAsyncSocket.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A26DBF02714541E004C251B /* CocoaAsyncSocket.xcframework */; };
+		4A26DBF827145435004C251B /* CocoaAsyncSocket.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4A26DBF02714541E004C251B /* CocoaAsyncSocket.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4A26DBFA27145488004C251B /* Starscream.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8870F42703F7E600DAF19F /* Starscream.xcframework */; };
+		4A26DBFB27145488004C251B /* Starscream.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8870F42703F7E600DAF19F /* Starscream.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4A26DBFC2714548B004C251B /* Starscream.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8870F42703F7E600DAF19F /* Starscream.xcframework */; };
+		4A26DBFD2714548B004C251B /* Starscream.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8870F42703F7E600DAF19F /* Starscream.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4A26DBFE2714548D004C251B /* Starscream.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8870F42703F7E600DAF19F /* Starscream.xcframework */; };
+		4A26DBFF2714548D004C251B /* Starscream.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8870F42703F7E600DAF19F /* Starscream.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		6EC871E323A421A200F69AE8 /* CocoaMQTTSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC871E223A421A200F69AE8 /* CocoaMQTTSocket.swift */; };
 		6EC871E523A421DE00F69AE8 /* CocoaMQTTWebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC871E423A421DE00F69AE8 /* CocoaMQTTWebSocket.swift */; };
 		8225B53A227C2FC600E4DB51 /* CocoaMQTT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0409977A1C1B1529006B5A6D /* CocoaMQTT.swift */; };
@@ -154,32 +160,38 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		1111242324BB4B7C00E2DFBC /* Embed Frameworks */ = {
+		4A26DBF32714541E004C251B /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				4A26DBFB27145488004C251B /* Starscream.xcframework in Embed Frameworks */,
+				4A26DBF22714541E004C251B /* CocoaAsyncSocket.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		111124AC24BB515E00E2DFBC /* Embed Frameworks */ = {
+		4A26DBF62714542A004C251B /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				4A26DBFD2714548B004C251B /* Starscream.xcframework in Embed Frameworks */,
+				4A26DBF52714542A004C251B /* CocoaAsyncSocket.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		111124D624BB516300E2DFBC /* Embed Frameworks */ = {
+		4A26DBF927145435004C251B /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				4A26DBFF2714548D004C251B /* Starscream.xcframework in Embed Frameworks */,
+				4A26DBF827145435004C251B /* CocoaAsyncSocket.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -205,12 +217,8 @@
 		0409977C1C1B1529006B5A6D /* CocoaMQTTMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaMQTTMessage.swift; sourceTree = "<group>"; };
 		111124B224BB515E00E2DFBC /* CocoaMQTT.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CocoaMQTT.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		111124DC24BB516400E2DFBC /* CocoaMQTT.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CocoaMQTT.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		11EBF5F324BB537A0096E199 /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/iOS/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
-		11EBF5F424BB537A0096E199 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
-		11EBF5F724BB53A00096E199 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/Mac/Starscream.framework; sourceTree = "<group>"; };
-		11EBF5F824BB53A00096E199 /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/Mac/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
-		11EBF5FB24BB53BC0096E199 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/tvOS/Starscream.framework; sourceTree = "<group>"; };
-		11EBF5FC24BB53BC0096E199 /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/tvOS/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
+		4A26DBF02714541E004C251B /* CocoaAsyncSocket.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CocoaAsyncSocket.xcframework; path = Carthage/Build/CocoaAsyncSocket.xcframework; sourceTree = "<group>"; };
+		4A8870F42703F7E600DAF19F /* Starscream.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Starscream.xcframework; path = Carthage/Build/Starscream.xcframework; sourceTree = "<group>"; };
 		6EC871E223A421A200F69AE8 /* CocoaMQTTSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaMQTTSocket.swift; sourceTree = "<group>"; };
 		6EC871E423A421DE00F69AE8 /* CocoaMQTTWebSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaMQTTWebSocket.swift; sourceTree = "<group>"; };
 		8225B4C8227B182200E4DB51 /* CocoaMQTTTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaMQTTTimer.swift; sourceTree = "<group>"; };
@@ -261,8 +269,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				11EBF5F924BB53A00096E199 /* Starscream.framework in Frameworks */,
-				11EBF5FA24BB53A00096E199 /* CocoaAsyncSocket.framework in Frameworks */,
+				4A26DBFC2714548B004C251B /* Starscream.xcframework in Frameworks */,
+				4A26DBF42714542A004C251B /* CocoaAsyncSocket.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -270,8 +278,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				11EBF5FD24BB53BC0096E199 /* Starscream.framework in Frameworks */,
-				11EBF5FE24BB53BC0096E199 /* CocoaAsyncSocket.framework in Frameworks */,
+				4A26DBFE2714548D004C251B /* Starscream.xcframework in Frameworks */,
+				4A26DBF727145435004C251B /* CocoaAsyncSocket.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -279,8 +287,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				11EBF5F524BB537A0096E199 /* CocoaAsyncSocket.framework in Frameworks */,
-				11EBF5F624BB537A0096E199 /* Starscream.framework in Frameworks */,
+				4A26DBFA27145488004C251B /* Starscream.xcframework in Frameworks */,
+				4A26DBF12714541E004C251B /* CocoaAsyncSocket.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -420,12 +428,8 @@
 		C68B087463924483F8568675 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				11EBF5FC24BB53BC0096E199 /* CocoaAsyncSocket.framework */,
-				11EBF5FB24BB53BC0096E199 /* Starscream.framework */,
-				11EBF5F824BB53A00096E199 /* CocoaAsyncSocket.framework */,
-				11EBF5F724BB53A00096E199 /* Starscream.framework */,
-				11EBF5F324BB537A0096E199 /* CocoaAsyncSocket.framework */,
-				11EBF5F424BB537A0096E199 /* Starscream.framework */,
+				4A26DBF02714541E004C251B /* CocoaAsyncSocket.xcframework */,
+				4A8870F42703F7E600DAF19F /* Starscream.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -468,7 +472,7 @@
 				1111248D24BB515E00E2DFBC /* Sources */,
 				111124A724BB515E00E2DFBC /* Frameworks */,
 				111124AA24BB515E00E2DFBC /* Resources */,
-				111124AC24BB515E00E2DFBC /* Embed Frameworks */,
+				4A26DBF62714542A004C251B /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -487,7 +491,7 @@
 				111124B724BB516300E2DFBC /* Sources */,
 				111124D124BB516300E2DFBC /* Frameworks */,
 				111124D424BB516300E2DFBC /* Resources */,
-				111124D624BB516300E2DFBC /* Embed Frameworks */,
+				4A26DBF927145435004C251B /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -506,7 +510,7 @@
 				8225B52E227C2E8700E4DB51 /* Sources */,
 				8225B52F227C2E8700E4DB51 /* Frameworks */,
 				8225B530227C2E8700E4DB51 /* Resources */,
-				1111242324BB4B7C00E2DFBC /* Embed Frameworks */,
+				4A26DBF32714541E004C251B /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -926,8 +930,9 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator";
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -960,7 +965,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.emqx.CocoaMQTT;
@@ -999,7 +1008,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.emqx.CocoaMQTT;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
@@ -1036,7 +1049,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.emqx.CocoaMQTT;
@@ -1075,7 +1092,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.emqx.CocoaMQTT;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
@@ -1113,7 +1134,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.emqx.CocoaMQTT;
@@ -1153,7 +1178,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.emqx.CocoaMQTT;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
@@ -1184,7 +1213,11 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = CocoaMQTTTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.emqx.CocoaMQTT-Tests";
@@ -1212,7 +1245,11 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = CocoaMQTTTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.emqx.CocoaMQTT-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
What have changed:
1. Update CocoaAsyncSocket to 7.6.5.
2. Use xcframework for dependencies.

I don't know if it is necessary to migrate to Xcode 13. Anyway I did it.
If you think stay on Xcode 11.1, just reject this pull request.