### PR TITLE
Add ability to connect via URI only

### DIFF
--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -50,6 +50,8 @@ public protocol CocoaMQTTWebSocketConnectionBuilder {
 public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
     
     public var enableSSL = false
+
+    public var shouldConnectWithURIOnly = false
     
     public var headers: [String: String] = [:]
 
@@ -91,8 +93,14 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
     }
     
     public func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws {
-        
-        let urlStr = "\(enableSSL ? "wss": "ws")://\(host):\(port)\(uri)"
+
+        var urlStr = ""
+
+        if shouldConnectWithURIOnly {
+            urlStr = "\(uri)"
+        } else {
+            urlStr = "\(enableSSL ? "wss": "ws")://\(host):\(port)\(uri)"
+        }
         
         guard let url = URL(string: urlStr) else { throw CocoaMQTTError.invalidURL }
         try internalQueue.sync {


### PR DESCRIPTION
Out of the box the library does not support establishing a wss MQTT connection via just the supplied URI.  You must inject the port number. 


This adds a var to `CocoaMQTTWebSocket` that allows the connection request to bypass the port number altogether, only using the supplied URI.