### PR TITLE
fix: CocoaMQTTTimer.swift memory leak

### DIFF
--- a/Source/CocoaMQTTTimer.swift
+++ b/Source/CocoaMQTTTimer.swift
@@ -39,7 +39,7 @@ class CocoaMQTTTimer {
     @discardableResult
     class func after(_ interval: TimeInterval, name: String, _ block: @escaping () -> Void) -> CocoaMQTTTimer {
         var timer : CocoaMQTTTimer? = CocoaMQTTTimer(delay: interval, name: name, timeInterval:0)
-        timer?.eventHandler = {
+        timer?.eventHandler = { [weak timer] in
             block()
             timer?.suspend()
             timer = nil


### PR DESCRIPTION
First of all, thanks for this amazing library.
I have noticed one minor memory leak in CocoaMQTTTimer class.
![Screenshot 2022-07-27 at 8 06 16 PM](https://user-images.githubusercontent.com/41371462/181286197-b904907d-f7e8-4a90-8179-d709d1db9115.png)
I am able to resolve it by these changes. Requesting you guys to have a look at it and merge it if there are no concerns. Thanks.

