### PR TITLE
Feature/fix3.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ Carthage/
 Cartfile.resolved
 xcenv.sh
 *.swp
+
+.build/

--- a/CocoaMQTTTests/CocoaMQTTTests.swift
+++ b/CocoaMQTTTests/CocoaMQTTTests.swift
@@ -39,7 +39,7 @@ class CocoaMQTTTests: XCTestCase {
         let mqtt = CocoaMQTT(clientID: clientID, host: host, port: port)
         mqtt.delegateQueue = deleQueue
         mqtt.delegate = caller
-        mqtt.logLevel = .debug
+        mqtt.logLevel = .error
         mqtt.autoReconnect = false
  
         _ = mqtt.connect()
@@ -102,7 +102,7 @@ class CocoaMQTTTests: XCTestCase {
         let mqtt = CocoaMQTT(clientID: clientID, host: "XXXXXXXXXXXX-ats.iot.eu-west-1.amazonaws.com", port: 443, socket: websocket)
         mqtt.delegateQueue = deleQueue
         mqtt.delegate = caller
-        mqtt.logLevel = .debug
+        mqtt.logLevel = .error
         mqtt.autoReconnect = false
         _ = mqtt.connect()
         wait_for { caller.isConnected }
@@ -134,7 +134,7 @@ class CocoaMQTTTests: XCTestCase {
         let mqtt = CocoaMQTT(clientID: clientID, host: host, port: 8083, socket: websocket)
         mqtt.delegateQueue = deleQueue
         mqtt.delegate = caller
-        mqtt.logLevel = .debug
+        mqtt.logLevel = .error
         mqtt.autoReconnect = false
         //mqtt.enableSSL = true
 
@@ -186,7 +186,7 @@ class CocoaMQTTTests: XCTestCase {
         let mqtt = CocoaMQTT(clientID: clientID, host: host, port: port)
         mqtt.delegateQueue = deleQueue
         mqtt.delegate = caller
-        mqtt.logLevel = .debug
+        mqtt.logLevel = .error
         mqtt.autoReconnect = true
         mqtt.autoReconnectTimeInterval = 1
         
@@ -214,7 +214,7 @@ class CocoaMQTTTests: XCTestCase {
         let mqtt = CocoaMQTT(clientID: clientID, host: host, port: port)
         mqtt.delegateQueue = deleQueue
         mqtt.delegate = caller
-        mqtt.logLevel = .debug
+        mqtt.logLevel = .error
         mqtt.autoReconnect = false
         
         _ = mqtt.connect()
@@ -245,7 +245,7 @@ class CocoaMQTTTests: XCTestCase {
         let mqtt = CocoaMQTT(clientID: clientID, host: host, port: port)
         mqtt.delegateQueue = deleQueue
         mqtt.delegate = caller
-        mqtt.logLevel = .debug
+        mqtt.logLevel = .error
         mqtt.autoReconnect = false
         
         _ = mqtt.connect()
@@ -276,13 +276,12 @@ class CocoaMQTTTests: XCTestCase {
         XCTAssertEqual(mqtt.connState, .disconnected)
     }
     
-    
     func testOnyWaySSL() {
         let caller = Caller()
         let mqtt = CocoaMQTT(clientID: clientID, host: host, port: sslport)
         mqtt.delegateQueue = deleQueue
         mqtt.delegate = caller
-        mqtt.logLevel = .debug
+        mqtt.logLevel = .error
         mqtt.enableSSL = true
         mqtt.allowUntrustCACertificate = true
         
@@ -301,7 +300,7 @@ class CocoaMQTTTests: XCTestCase {
         let mqtt = CocoaMQTT(clientID: clientID, host: host, port: sslport)
         mqtt.delegateQueue = deleQueue
         mqtt.delegate = caller
-        mqtt.logLevel = .debug
+        mqtt.logLevel = .error
         mqtt.enableSSL = true
         mqtt.allowUntrustCACertificate = true
         

--- a/CocoaMQTTTests/FrameTests.swift
+++ b/CocoaMQTTTests/FrameTests.swift
@@ -11,26 +11,18 @@ import XCTest
 
 class FrameTests: XCTestCase {
 
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
     func testFrameConnect() {
         var conn = FrameConnect(clientID: "sheep")
-        conn.keepalive = 60
+        conn.keepAlive = 60
         conn.cleansess = true
         
-        XCTAssertEqual(conn.fixedHeader, 0x10)
+        XCTAssertEqual(conn.packetFixedHeaderType, 0x10)
         XCTAssertEqual(conn.type, FrameType.connect)
         XCTAssertEqual(conn.dup, false)
         XCTAssertEqual(conn.qos, .qos0)
         XCTAssertEqual(conn.retained, false)
         
-        XCTAssertEqual(conn.bytes(),
+        XCTAssertEqual(conn.bytes(version: "3.1.1"),
                        [0x10, 0x11,
                         0x00, 0x04, 0x4D, 0x51, 0x54, 0x54,         // MQTT
                         0x04,                                       // Protocol Version - 4
@@ -43,7 +35,7 @@ class FrameTests: XCTestCase {
         conn.willMsg = CocoaMQTTMessage(topic: "t/1", string: "Banalana", qos: .qos2, retained: true)
         conn.cleansess = false
         
-        XCTAssertEqual(conn.bytes(),
+        XCTAssertEqual(conn.bytes(version: "3.1.1"),
                        [0x10, 0x2B,
                         0x00, 0x04, 0x4D, 0x51, 0x54, 0x54,         // MQTT
                         0x04,                                       // Protocol Version - 4
@@ -57,17 +49,17 @@ class FrameTests: XCTestCase {
     }
     
     func testFrameConAck() {
-        var connack = FrameConnAck(code: .accept)
-        var bytes = [UInt8](connack.bytes()[2...])
-        var connack2 = FrameConnAck(fixedHeader: FrameType.connack.rawValue, bytes: bytes)
+        var connack = FrameConnAck(returnCode: .accept)
+        var bytes = [UInt8](connack.bytes(version: "3.1.1")[2...])
+        var connack2 = FrameConnAck(packetFixedHeaderType: FrameType.connack.rawValue, bytes: bytes)
         
         XCTAssertEqual(connack.returnCode, connack2?.returnCode)
         XCTAssertEqual(connack.sessPresent, connack2?.sessPresent)
         
         connack.returnCode = .notAuthorized
         connack.sessPresent = true
-        bytes = [UInt8](connack.bytes()[2...])
-        connack2 = FrameConnAck(fixedHeader: FrameType.connack.rawValue, bytes: bytes)
+        bytes = [UInt8](connack.bytes(version: "3.1.1")[2...])
+        connack2 = FrameConnAck(packetFixedHeaderType: FrameType.connack.rawValue, bytes: bytes)
         
         XCTAssertEqual(connack.returnCode, connack2?.returnCode)
         XCTAssertEqual(connack.sessPresent, connack2?.sessPresent)
@@ -76,8 +68,8 @@ class FrameTests: XCTestCase {
     func testFramePublish() {
         
         var publish = FramePublish(topic: "t/a", payload: "aaa".utf8 + [], qos: .qos0, msgid: 0x0010)
-        var bytes = [UInt8](publish.bytes()[2...])
-        var publish2 = FramePublish(fixedHeader: FrameType.publish.rawValue, bytes: bytes)
+        var bytes = [UInt8](publish.bytes(version: "3.1.1")[2...])
+        var publish2 = FramePublish(packetFixedHeaderType: FrameType.publish.rawValue, bytes: bytes)
         
         XCTAssertEqual(publish.dup, publish2?.dup)
         XCTAssertEqual(publish.qos, publish2?.qos)
@@ -94,9 +86,8 @@ class FrameTests: XCTestCase {
         publish.topic = "t/b"
         publish._payload = "bbb".utf8 + []
         
-        
-        bytes = [UInt8](publish.bytes()[2...])
-        publish2 = FramePublish(fixedHeader: 0x35, bytes: bytes)
+        bytes = [UInt8](publish.bytes(version: "3.1.1")[2...])
+        publish2 = FramePublish(packetFixedHeaderType: 0x35, bytes: bytes)
         
         XCTAssertEqual(publish.dup, publish2?.dup)
         XCTAssertEqual(publish.qos, publish2?.qos)
@@ -107,17 +98,17 @@ class FrameTests: XCTestCase {
         
         
         // -- Property GET/SET
-        
         // PUBLISH - QOS2 - DUP - RETAINED
-        guard var f0 = FramePublish(fixedHeader: 0x3D,
+        guard var f0 = FramePublish(packetFixedHeaderType: 0x3D,
                                     bytes: [0x00, 0x03, 0x74, 0x2f, 0x61, // topic = t/a
                                             0x00, 0x10,                   // msgid = 16
                                             0x61, 0x61, 0x61]) else {     // payload = aaa
             XCTAssertTrue(false)
             return
         }
-        XCTAssertEqual(f0.fixedHeader, 0x3D)
+        XCTAssertEqual(f0.packetFixedHeaderType, 0x3D)
         XCTAssertEqual(f0.type, FrameType.publish)
+        // TODO: Fix dup
         XCTAssertEqual(f0.dup, true)
         XCTAssertEqual(f0.qos, .qos2)
         XCTAssertEqual(f0.retained, true)
@@ -149,118 +140,120 @@ class FrameTests: XCTestCase {
         f0.retained = false
         XCTAssertEqual(f0.retained, false)
         
-        let f1 = FramePublish(fixedHeader: 0x30, bytes:[0, 60, 47, 114, 101, 109, 111, 116, 101, 97, 112, 112, 47, 109, 111, 98, 105, 108, 101, 47, 98, 114, 111, 97, 100, 99, 97, 115, 116, 47, 112, 108, 97, 116, 102, 111, 114, 109, 95, 115, 101, 114, 118, 105, 99, 101, 47, 97, 99, 116, 105, 111, 110, 115, 47, 116, 118, 115, 108, 101, 101, 112])
+        let f1 = FramePublish(packetFixedHeaderType: 0x30, bytes:[0, 60, 47, 114, 101, 109, 111, 116, 101, 97, 112, 112, 47, 109, 111, 98, 105, 108, 101, 47, 98, 114, 111, 97, 100, 99, 97, 115, 116, 47, 112, 108, 97, 116, 102, 111, 114, 109, 95, 115, 101, 114, 118, 105, 99, 101, 47, 97, 99, 116, 105, 111, 110, 115, 47, 116, 118, 115, 108, 101, 101, 112])
         XCTAssertEqual(f1?.payload().count, 0)
     }
     
     func testFramePubAck() {
         
         var puback = FramePubAck(msgid: 0x1010)
-        var bytes = [UInt8](puback.bytes()[2...])
-        var puback2 = FramePubAck(fixedHeader: FrameType.puback.rawValue, bytes: bytes)
+        var bytes = [UInt8](puback.bytes(version: "3.1.1")[2...])
+        var puback2 = FramePubAck(packetFixedHeaderType: FrameType.puback.rawValue, bytes: bytes)
         
-        XCTAssertEqual(puback.fixedHeader, puback2?.fixedHeader)
+        XCTAssertEqual(puback.packetFixedHeaderType, puback2?.packetFixedHeaderType)
         XCTAssertEqual(puback.msgid, puback2?.msgid)
         
-        XCTAssertEqual(puback2?.fixedHeader, 0x40)
+        XCTAssertEqual(puback2?.packetFixedHeaderType, 0x40)
         XCTAssertEqual(puback2?.msgid, 0x1010)
-        XCTAssertEqual(puback2?.bytes(), [0x40, 0x02, 0x10, 0x10])
+        XCTAssertEqual(puback2?.bytes(version: "3.1.1"), [0x40, 0x02, 0x10, 0x10])
         
         puback.msgid = 0x1011
-        bytes = [UInt8](puback.bytes()[2...])
-        puback2 = FramePubAck(fixedHeader: FrameType.puback.rawValue, bytes: bytes)
+        bytes = [UInt8](puback.bytes(version: "3.1.1")[2...])
+        puback2 = FramePubAck(packetFixedHeaderType: FrameType.puback.rawValue, bytes: bytes)
         
-        XCTAssertEqual(puback.fixedHeader, puback2?.fixedHeader)
+        XCTAssertEqual(puback.packetFixedHeaderType, puback2?.packetFixedHeaderType)
         XCTAssertEqual(puback.msgid, puback2?.msgid)
         
-        XCTAssertEqual(puback2?.fixedHeader, 0x40)
+        XCTAssertEqual(puback2?.packetFixedHeaderType, 0x40)
         XCTAssertEqual(puback2?.msgid, 0x1011)
-        XCTAssertEqual(puback2?.bytes(), [0x40, 0x02, 0x10, 0x11])
+        XCTAssertEqual(puback2?.bytes(version: "3.1.1"), [0x40, 0x02, 0x10, 0x11])
     }
     
     func testFramePubRec() {
         var pubrec = FramePubRec(msgid: 0x1010)
-        var bytes = [UInt8](pubrec.bytes()[2...])
-        var pubrec2 = FramePubRec(fixedHeader: FrameType.pubrec.rawValue, bytes: bytes)
+        var bytes = [UInt8](pubrec.bytes(version: "3.1.1")[2...])
+        var pubrec2 = FramePubRec(packetFixedHeaderType: FrameType.pubrec.rawValue, bytes: bytes)
         
-        XCTAssertEqual(pubrec.fixedHeader, pubrec2?.fixedHeader)
+        XCTAssertEqual(pubrec.packetFixedHeaderType, pubrec2?.packetFixedHeaderType)
         XCTAssertEqual(pubrec.msgid, pubrec2?.msgid)
         
-        XCTAssertEqual(pubrec2?.fixedHeader, 0x50)
+        XCTAssertEqual(pubrec2?.packetFixedHeaderType, 0x50)
         XCTAssertEqual(pubrec2?.msgid, 0x1010)
-        XCTAssertEqual(pubrec2?.bytes(), [0x50, 0x02, 0x10, 0x10])
+        XCTAssertEqual(pubrec2?.bytes(version: "3.1.1"), [0x50, 0x02, 0x10, 0x10])
         
         pubrec.msgid = 0x1011
-        bytes = [UInt8](pubrec.bytes()[2...])
-        pubrec2 = FramePubRec(fixedHeader: FrameType.pubrec.rawValue, bytes: bytes)
+        bytes = [UInt8](pubrec.bytes(version: "3.1.1")[2...])
+        pubrec2 = FramePubRec(packetFixedHeaderType: FrameType.pubrec.rawValue, bytes: bytes)
         
-        XCTAssertEqual(pubrec.fixedHeader, pubrec2?.fixedHeader)
+        XCTAssertEqual(pubrec.packetFixedHeaderType, pubrec2?.packetFixedHeaderType)
         XCTAssertEqual(pubrec.msgid, pubrec2?.msgid)
         
-        XCTAssertEqual(pubrec2?.fixedHeader, 0x50)
+        XCTAssertEqual(pubrec2?.packetFixedHeaderType, 0x50)
         XCTAssertEqual(pubrec2?.msgid, 0x1011)
-        XCTAssertEqual(pubrec2?.bytes(), [0x50, 0x02, 0x10, 0x11])
+        XCTAssertEqual(pubrec2?.bytes(version: "3.1.1"), [0x50, 0x02, 0x10, 0x11])
     }
     
     func testFramePubRel() {
      
         var pubrel = FramePubRel(msgid: 0x1010)
-        var bytes = [UInt8](pubrel.bytes()[2...])
-        var pubrel2 = FramePubRel(fixedHeader: 0x62, bytes: bytes)
+        var bytes = [UInt8](pubrel.bytes(version: "3.1.1")[2...])
+        var pubrel2 = FramePubRel(packetFixedHeaderType: 0x62, bytes: bytes)
         
-        XCTAssertEqual(pubrel.fixedHeader, pubrel2?.fixedHeader)
+        XCTAssertEqual(pubrel.packetFixedHeaderType, pubrel2?.packetFixedHeaderType)
         XCTAssertEqual(pubrel.msgid, pubrel2?.msgid)
         
-        XCTAssertEqual(pubrel2?.fixedHeader, 0x62)
+        XCTAssertEqual(pubrel2?.packetFixedHeaderType, 0x62)
         XCTAssertEqual(pubrel2?.msgid, 0x1010)
-        XCTAssertEqual(pubrel2?.bytes(), [0x62, 0x02, 0x10, 0x10])
+        XCTAssertEqual(pubrel2?.bytes(version: "3.1.1"), [0x62, 0x02, 0x10, 0x10])
         
         pubrel.msgid = 0x1011
-        bytes = [UInt8](pubrel.bytes()[2...])
-        pubrel2 = FramePubRel(fixedHeader: 0x62, bytes: bytes)
+        bytes = [UInt8](pubrel.bytes(version: "3.1.1")[2...])
+        pubrel2 = FramePubRel(packetFixedHeaderType: 0x62, bytes: bytes)
         
-        XCTAssertEqual(pubrel.fixedHeader, pubrel2?.fixedHeader)
+        XCTAssertEqual(pubrel.packetFixedHeaderType, pubrel2?.packetFixedHeaderType)
         XCTAssertEqual(pubrel.msgid, pubrel2?.msgid)
         
-        XCTAssertEqual(pubrel2?.fixedHeader, 0x62)
+        XCTAssertEqual(pubrel2?.packetFixedHeaderType, 0x62)
         XCTAssertEqual(pubrel2?.msgid, 0x1011)
-        XCTAssertEqual(pubrel2?.bytes(), [0x62, 0x02, 0x10, 0x11])
+        XCTAssertEqual(pubrel2?.bytes(version: "3.1.1"), [0x62, 0x02, 0x10, 0x11])
     }
     
     func testFramePubComp() {
         var pubcomp = FramePubComp(msgid: 0x1010)
-        var bytes = [UInt8](pubcomp.bytes()[2...])
-        var pubcomp2 = FramePubComp(fixedHeader: FrameType.pubcomp.rawValue, bytes: bytes)
+        var bytes = [UInt8](pubcomp.bytes(version: "3.1.1")[2...])
+        var pubcomp2 = FramePubComp(packetFixedHeaderType: FrameType.pubcomp.rawValue, bytes: bytes)
         
-        XCTAssertEqual(pubcomp.fixedHeader, pubcomp2?.fixedHeader)
+        XCTAssertEqual(pubcomp.packetFixedHeaderType, pubcomp2?.packetFixedHeaderType)
         XCTAssertEqual(pubcomp.msgid, pubcomp2?.msgid)
         
-        XCTAssertEqual(pubcomp2?.fixedHeader, 0x70)
+        XCTAssertEqual(pubcomp2?.packetFixedHeaderType, 0x70)
         XCTAssertEqual(pubcomp2?.msgid, 0x1010)
-        XCTAssertEqual(pubcomp2?.bytes(), [0x70, 0x02, 0x10, 0x10])
+        XCTAssertEqual(pubcomp2?.bytes(version: "3.1.1"), [0x70, 0x02, 0x10, 0x10])
         
         pubcomp.msgid = 0x1011
-        bytes = [UInt8](pubcomp.bytes()[2...])
-        pubcomp2 = FramePubComp(fixedHeader: FrameType.pubcomp.rawValue, bytes: bytes)
+        bytes = [UInt8](pubcomp.bytes(version: "3.1.1")[2...])
+        pubcomp2 = FramePubComp(packetFixedHeaderType: FrameType.pubcomp.rawValue, bytes: bytes)
         
-        XCTAssertEqual(pubcomp.fixedHeader, pubcomp2?.fixedHeader)
+        XCTAssertEqual(pubcomp.packetFixedHeaderType, pubcomp2?.packetFixedHeaderType)
         XCTAssertEqual(pubcomp.msgid, pubcomp2?.msgid)
         
-        XCTAssertEqual(pubcomp2?.fixedHeader, 0x70)
+        XCTAssertEqual(pubcomp2?.packetFixedHeaderType, 0x70)
         XCTAssertEqual(pubcomp2?.msgid, 0x1011)
-        XCTAssertEqual(pubcomp2?.bytes(), [0x70, 0x02, 0x10, 0x11])
+        XCTAssertEqual(pubcomp2?.bytes(version: "3.1.1"), [0x70, 0x02, 0x10, 0x11])
     }
     
-    func testFrameSubscribe() {
+    func testFrameSubscribe() throws {
         let subscribe = FrameSubscribe(msgid: 0x1010, topic: "topic", reqos: .qos1)
-        XCTAssertEqual(subscribe.fixedHeader, 0x82)
+        XCTAssertEqual(subscribe.packetFixedHeaderType, 0x82)
         XCTAssertEqual(subscribe.msgid, 0x1010)
-        XCTAssertEqual(subscribe.topics.count, 1)
-        for (t, qos) in subscribe.topics {
+
+        let topics = try XCTUnwrap(subscribe.topics)
+        XCTAssertEqual(topics.count, 1)
+        for (t, qos) in topics {
             XCTAssertEqual(t, "topic")
             XCTAssertEqual(qos, .qos1)
         }
-        XCTAssertEqual(subscribe.bytes(),
+        XCTAssertEqual(subscribe.bytes(version: "3.1.1"),
                        [0x82, 0x0A,
                         0x10, 0x10,
                         0x00, 0x05, 0x74, 0x6F, 0x70, 0x69, 0x63,
@@ -270,10 +263,10 @@ class FrameTests: XCTestCase {
     func testFrameSubAck() {
         
         var suback = FrameSubAck(msgid: 0x1010, grantedQos: [.qos0, .FAILURE, .qos2])
-        var bytes = [UInt8](suback.bytes()[2...])
-        var suback2 = FrameSubAck(fixedHeader: FrameType.suback.rawValue, bytes: bytes)
+        var bytes = [UInt8](suback.bytes(version: "3.1.1")[2...])
+        var suback2 = FrameSubAck(packetFixedHeaderType: FrameType.suback.rawValue, bytes: bytes)
         
-        XCTAssertEqual(suback.fixedHeader, suback2?.fixedHeader)
+        XCTAssertEqual(suback.packetFixedHeaderType, suback2?.packetFixedHeaderType)
         XCTAssertEqual(suback.msgid, suback2?.msgid)
         XCTAssertEqual(suback.grantedQos, suback2?.grantedQos)
         
@@ -282,14 +275,14 @@ class FrameTests: XCTestCase {
         XCTAssertEqual(suback2?.dup, false)
         XCTAssertEqual(suback2?.retained, false)
         XCTAssertEqual(suback2?.msgid, 0x1010)
-        XCTAssertEqual(suback2?.grantedQos, [.qos0, .FAILTURE, .qos2])
+        XCTAssertEqual(suback2?.grantedQos, [.qos0, .FAILURE, .qos2])
         
         suback.msgid = 0x1011
         suback.grantedQos = [.qos0]
-        bytes = [UInt8](suback.bytes()[2...])
-        suback2 = FrameSubAck(fixedHeader: FrameType.suback.rawValue, bytes: bytes)
+        bytes = [UInt8](suback.bytes(version: "3.1.1")[2...])
+        suback2 = FrameSubAck(packetFixedHeaderType: FrameType.suback.rawValue, bytes: bytes)
         
-        XCTAssertEqual(suback.fixedHeader, suback2?.fixedHeader)
+        XCTAssertEqual(suback.packetFixedHeaderType, suback2?.packetFixedHeaderType)
         XCTAssertEqual(suback.msgid, suback2?.msgid)
         XCTAssertEqual(suback.grantedQos, suback2?.grantedQos)
     }
@@ -297,11 +290,10 @@ class FrameTests: XCTestCase {
     func testFrameUnsubscribe() {
         
         let unsub = FrameUnsubscribe(msgid: 0x1010, topics: ["topic", "t2"])
-
-        XCTAssertEqual(unsub.fixedHeader, 0xA2)
+        XCTAssertEqual(unsub.packetFixedHeaderType, 0xA2)
         XCTAssertEqual(unsub.msgid, 0x1010)
         XCTAssertEqual(unsub.topics, ["topic", "t2"])
-        XCTAssertEqual(unsub.bytes(),
+        XCTAssertEqual(unsub.bytes(version: "3.1.1"),
                        [0xA2, 0x0d,
                         0x10, 0x10,
                         0x00, 0x05, 0x74, 0x6F, 0x70, 0x69, 0x63,
@@ -310,11 +302,11 @@ class FrameTests: XCTestCase {
     
     func testFrameUnsubAck() {
         
-        var unsuback = FrameUnsubAck(msgid: 0x1010)
-        var bytes = [UInt8](unsuback.bytes()[2...])
-        var unsuback2 = FrameUnsubAck(fixedHeader: FrameType.unsuback.rawValue, bytes: bytes)
+        var unsuback = FrameUnsubAck(msgid: 0x1010, payload: [])
+        var bytes = [UInt8](unsuback.bytes(version: "3.1.1")[2...])
+        var unsuback2 = FrameUnsubAck(packetFixedHeaderType: FrameType.unsuback.rawValue, bytes: bytes)
         
-        XCTAssertEqual(unsuback.fixedHeader, unsuback2?.fixedHeader)
+        XCTAssertEqual(unsuback.packetFixedHeaderType, unsuback2?.packetFixedHeaderType)
         XCTAssertEqual(unsuback.msgid, unsuback2?.msgid)
         XCTAssertEqual(unsuback2?.type, .unsuback)
         XCTAssertEqual(unsuback2?.dup, false)
@@ -322,10 +314,10 @@ class FrameTests: XCTestCase {
         XCTAssertEqual(unsuback2?.retained, false)
         
         unsuback.msgid = 0x1011
-        bytes = [UInt8](unsuback.bytes()[2...])
-        unsuback2 = FrameUnsubAck(fixedHeader: FrameType.unsuback.rawValue, bytes: bytes)
+        bytes = [UInt8](unsuback.bytes(version: "3.1.1")[2...])
+        unsuback2 = FrameUnsubAck(packetFixedHeaderType: FrameType.unsuback.rawValue, bytes: bytes)
         
-        XCTAssertEqual(unsuback.fixedHeader, unsuback2?.fixedHeader)
+        XCTAssertEqual(unsuback.packetFixedHeaderType, unsuback2?.packetFixedHeaderType)
         XCTAssertEqual(unsuback.msgid, unsuback2?.msgid)
         XCTAssertEqual(unsuback2?.type, .unsuback)
         XCTAssertEqual(unsuback2?.dup, false)
@@ -337,25 +329,25 @@ class FrameTests: XCTestCase {
         
         let ping = FramePingReq()
         
-        XCTAssertEqual(ping.fixedHeader, 0xC0)
-        XCTAssertEqual(ping.bytes(), [0xC0, 0x00])
+        XCTAssertEqual(ping.packetFixedHeaderType, 0xC0)
+        XCTAssertEqual(ping.bytes(version: "3.1.1"), [0xC0, 0x00])
     }
     
     func testFramePong() {
         
         let pong = FramePingResp()
-        let bytes = [UInt8](pong.bytes()[2...])
-        let pong2 = FramePingResp(fixedHeader: FrameType.pingresp.rawValue, bytes: bytes)
+        let bytes = [UInt8](pong.bytes(version: "3.1.1")[2...])
+        let pong2 = FramePingResp(packetFixedHeaderType: FrameType.pingresp.rawValue, bytes: bytes)
         
-        XCTAssertEqual(pong.fixedHeader, pong2?.fixedHeader)
-        XCTAssertEqual(pong.bytes(), [0xD0, 0x00])
+        XCTAssertEqual(pong.packetFixedHeaderType, pong2?.packetFixedHeaderType)
+        XCTAssertEqual(pong.bytes(version: "3.1.1"), [0xD0, 0x00])
     }
     
     func testFrameDisconnect() {
         
         let disconn = FrameDisconnect()
         
-        XCTAssertEqual(disconn.fixedHeader, 0xE0)
-        XCTAssertEqual(disconn.bytes(), [0xE0, 0x00])
+        XCTAssertEqual(disconn.packetFixedHeaderType, 0xE0)
+        XCTAssertEqual(disconn.bytes(version: "3.1.1"), [0xE0, 0x00])
     }
 }

--- a/Source/CocoaMQTTStorage.swift
+++ b/Source/CocoaMQTTStorage.swift
@@ -113,11 +113,12 @@ final class CocoaMQTTStorage: CocoaMQTTStorageProtocol {
     }
 
     private func parse(_ bytes: [UInt8]) -> (UInt8, [UInt8])? {
-        guard bytes.count > 5 else {
+        // FramePubRel is 4 bytes long
+        guard bytes.count > 3 else {
             return nil
         }
         /// bytes 1..<5 may be 'Remaining Length'
-        for i in 1 ..< 5 {
+        for i in 1 ..< min(5, bytes.count){
             if (bytes[i] & 0x80) == 0 {
                 return (bytes[0], Array(bytes.suffix(from: i+1)))
             }

--- a/Source/Frame.swift
+++ b/Source/Frame.swift
@@ -191,7 +191,6 @@ extension Frame {
             return ((packetFixedHeaderType & 0x08) >> 3) == 0 ? false : true
         }
         set {
-            packetFixedHeaderType = self.fixedHeader().first ?? packetFixedHeaderType
             packetFixedHeaderType = (packetFixedHeaderType & 0xF7) | (newValue.bit  << 3)
         }
     }
@@ -202,7 +201,6 @@ extension Frame {
             return CocoaMQTTQoS(rawValue: (packetFixedHeaderType & 0x06) >> 1)!
         }
         set {
-            packetFixedHeaderType = self.fixedHeader().first ?? packetFixedHeaderType
             packetFixedHeaderType = (packetFixedHeaderType & 0xF9) | (newValue.rawValue << 1)
         }
     }
@@ -213,7 +211,6 @@ extension Frame {
             return (packetFixedHeaderType & 0x01) == 0 ? false : true
         }
         set {
-            packetFixedHeaderType = self.fixedHeader().first ?? packetFixedHeaderType
             packetFixedHeaderType = (packetFixedHeaderType & 0xFE) | newValue.bit
         }
     }

--- a/Source/FrameConnAck.swift
+++ b/Source/FrameConnAck.swift
@@ -31,6 +31,10 @@ struct FrameConnAck: Frame {
     //3.2.3 CONNACK Payload
     //The CONNACK packet has no Payload.
 
+    ///MQTT 3.1.1
+    init(returnCode: CocoaMQTTConnAck) {
+        self.returnCode = returnCode
+    }
 
     ///MQTT 5.0
     init(code: CocoaMQTTCONNACKReasonCode) {

--- a/Source/FramePublish.swift
+++ b/Source/FramePublish.swift
@@ -17,6 +17,7 @@ struct FramePublish: Frame {
     //public var qos: CocoaMQTTQoS = .qos1
     //3.3.1.3 RETAIN
     public var retain: Bool = false
+
     //3.3.1.4 Remaining Length
     public var remainingLength: UInt32?
 
@@ -122,13 +123,13 @@ extension FramePublish: InitialWithBytes {
         guard packetFixedHeaderType & 0xF0 == FrameType.publish.rawValue else {
             return nil
         }
+        let recDup = ((packetFixedHeaderType & 0b0000_1000) >> 3) > 0
 
-        let recDup = (packetFixedHeaderType & 0b0000_1000 >> 3) > 0
         guard let recQos = CocoaMQTTQoS(rawValue: (packetFixedHeaderType & 0b0000_0110) >> 1) else {
             return nil
         }
-        let recRetain = packetFixedHeaderType & 0b0000_0001 > 0
 
+        let recRetain = (packetFixedHeaderType & 0b0000_0001) > 0
         // Reserved
         var flags: UInt8 = 0
 
@@ -154,7 +155,6 @@ extension FramePublish: InitialWithBytes {
         case .FAILURE:
             printDebug("FAILTURE")
         }
-        
         self.packetFixedHeaderType = flags
 
         /// Packet Identifier

--- a/Source/FramePublish.swift
+++ b/Source/FramePublish.swift
@@ -11,13 +11,6 @@ import Foundation
 // MQTT PUBLISH Frame
 struct FramePublish: Frame {
 
-    //3.3.1.1 DUP
-    public var dup: Bool = false
-    //3.3.1.2 QoS
-    //public var qos: CocoaMQTTQoS = .qos1
-    //3.3.1.3 RETAIN
-    public var retain: Bool = false
-
     //3.3.1.4 Remaining Length
     public var remainingLength: UInt32?
 


### PR DESCRIPTION
In this PR I have fixed unit tests which looks like were broken since support for MQTT 5.0 was added. Also I have fixed several issues with 3.1.1 implementation. The biggest isseu was with flags reset in Frame extension for qos, dup and retained.