### PR TITLE
fix: Update Package.resolved.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/leeway1208/MqttCocoaAsyncSocket",
         "state": {
           "branch": null,
-          "revision": "8c61a10eab8c9bc3a4d28883c1a25f6a271400f2",
-          "version": "1.0.5"
+          "revision": "5b9bc4dc065cfae7faf24537190f82d5a3e4932d",
+          "version": "1.0.6"
         }
       },
       {
@@ -15,17 +15,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream.git",
         "state": {
           "branch": null,
-          "revision": "e6b65c6d9077ea48b4a7bdda8994a1d3c6969c8d",
-          "version": "3.1.1"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
+          "revision": "a063fda2b8145a231953c20e7a646be254365396",
+          "version": "3.1.2"
         }
       }
     ]


### PR DESCRIPTION
There's a build error when adding this dependency through SPM. 
I think that is because in Package.resolved the version for `MqttCocoaAsyncSocket` is 1.0.5. Updating that.