### PR TITLE
Fix timer var warning

### DIFF
--- a/Source/CocoaMQTTTimer.swift
+++ b/Source/CocoaMQTTTimer.swift
@@ -38,7 +38,7 @@ class CocoaMQTTTimer {
     
     @discardableResult
     class func after(_ interval: TimeInterval, name: String, _ block: @escaping () -> Void) -> CocoaMQTTTimer {
-        var timer : CocoaMQTTTimer? = CocoaMQTTTimer(delay: interval, name: name, timeInterval:0)
+        let timer: CocoaMQTTTimer? = CocoaMQTTTimer(delay: interval, name: name, timeInterval: 0)
         timer?.eventHandler = { [weak timer] in
             block()
             timer?.suspend()


### PR DESCRIPTION
This fixes the following warning.
```
Variable 'timer' was never mutated; consider changing to 'let' constant
```