### PR TITLE
fix: auto reconnection not working

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -392,7 +392,6 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     ///         disconnect expectedly
     public func disconnect() {
         internal_disconnect()
-        is_internal_disconnected = false
     }
     
     /// Disconnect unexpectedly
@@ -589,7 +588,7 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
         delegate?.mqttDidDisconnect(self, withError: err)
         didDisconnect(self, err)
 
-        guard is_internal_disconnected else {
+        guard !is_internal_disconnected else {
             return
         }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -411,12 +411,10 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     ///         disconnect expectedly
     public func disconnect() {
         internal_disconnect()
-        is_internal_disconnected = false
     }
 
     public func disconnect(reasonCode : CocoaMQTTDISCONNECTReasonCode,userProperties : [String: String] ) {
         internal_disconnect_withProperties(reasonCode: reasonCode,userProperties: userProperties)
-        is_internal_disconnected = false
     }
 
     /// Disconnect unexpectedly
@@ -644,7 +642,7 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         delegate?.mqtt5DidDisconnect(self, withError: err)
         didDisconnect(self, err)
 
-        guard is_internal_disconnected else {
+        guard !is_internal_disconnected else {
             return
         }
 


### PR DESCRIPTION
Fixed auto reconnection not working when a socket disconnected.

This issue is a side effect of the PR below.
https://github.com/emqx/CocoaMQTT/pull/466

Fixed incorrect `is_internal_disconnected` guard condition and removed code that initialized `is_internal_disconnected` unnecessarily.
