### PR TITLE
Fixes data race when write result is reported.

### DIFF
--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -326,7 +326,9 @@ public extension CocoaMQTTWebSocket {
         
         public func write(data: Data, handler: @escaping (Error?) -> Void) {
             task?.send(.data(data)) { possibleError in
-                handler(possibleError)
+                self.queue.async {
+                    handler(possibleError)
+                }
             }
         }
         


### PR DESCRIPTION
Even though queue is assigned to FoundationConnection it's never used for write results like it's used for reads.