### PR TITLE
Fix overflow crash when reading length

### DIFF
--- a/Source/CocoaMQTTReader.swift
+++ b/Source/CocoaMQTTReader.swift
@@ -77,7 +77,8 @@ class CocoaMQTTReader {
             }
             // more
         } else {
-            multiply *= 128
+            let result = multiply.multipliedReportingOverflow(by: 128)
+            multiply = result.partialValue
             readLength()
         }
     }


### PR DESCRIPTION
Another quite "popular" crash we have is related to multiplication overflow. This is workaround for this issue.

<img width="1090" alt="Screenshot 2023-02-03 at 11 27 36" src="https://user-images.githubusercontent.com/16134919/216577103-40d2bfb0-5515-4a19-9147-9ed40601d912.png">


**Importat note** This is more like workaround but my knowledge of MQTT standard and logic inside library is to little to suggest something better. I would like to ask @leeway1208 for some help here because most probably, it's not right way to fix this.