### PR TITLE
add mqtt alpn support

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -156,6 +156,7 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     
     public var password: String?
     
+    public var sslAlpn: String?
     /// Clean Session flag. Default is true
     ///
     /// - TODO: What's behavior each Clean Session flags???
@@ -560,6 +561,9 @@ extension CocoaMQTT {
 extension CocoaMQTT: CocoaMQTTSocketDelegate {
     
     public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+        if socket.enableSSL{
+            socket.configureSslAlpn(self.sslAlpn)
+        }
         sendConnectFrame()
     }
     

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -151,6 +151,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     public var password: String?
 
+    public var sslAlpn: String?
     /// Clean Session flag. Default is true
     ///
     /// - TODO: What's behavior each Clean Session flags???
@@ -616,6 +617,9 @@ extension CocoaMQTT5 {
 extension CocoaMQTT5: CocoaMQTTSocketDelegate {
 
     public func socketConnected(_ socket: CocoaMQTTSocketProtocol) {
+        if socket.enableSSL{
+            socket.configureSslAlpn(self.sslAlpn)
+        }
         sendConnectFrame()
     }
 

--- a/Source/CocoaMQTTSocket.swift
+++ b/Source/CocoaMQTTSocket.swift
@@ -23,6 +23,7 @@ public protocol CocoaMQTTSocketProtocol {
     
     var enableSSL: Bool { get set }
     
+    func configureSslAlpn(_ alpn:String?)
     func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?)
     func connect(toHost host: String, onPort port: UInt16) throws
     func connect(toHost host: String, onPort port: UInt16, withTimeout timeout: TimeInterval) throws
@@ -38,7 +39,7 @@ public class CocoaMQTTSocket: NSObject {
     public var backgroundOnSocket = true
 
     public var enableSSL = false
-    
+
     ///
     public var sslSettings: [String: NSObject]?
     
@@ -54,6 +55,19 @@ public class CocoaMQTTSocket: NSObject {
 }
 
 extension CocoaMQTTSocket: CocoaMQTTSocketProtocol {
+    public func configureSslAlpn(_ alpn:String?){
+        if let alpn = alpn {
+            if #available(iOS 11.0, *) {
+                // Get the SSL Context
+                guard let context = reference.sslContext() else {
+                    return
+                }
+                // Set ALPN protocol list
+                let protocols = [alpn] as CFArray
+                SSLSetALPNProtocols(context.takeRetainedValue(), protocols)
+            }
+        }
+    }
     public func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
         delegate = theDelegate
         reference.setDelegate((delegate != nil ? self : nil), delegateQueue: delegateQueue)

--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -77,6 +77,11 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
         }
     }
     
+    public func configureSslAlpn(_ alpn:String?){
+        // not implemented
+        abort()
+    }
+    
     public func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
         internalQueue.async {
             self.delegate = theDelegate


### PR DESCRIPTION
I want to use CocoaMQTT for AWS IOT MQTT with custom authorizer username and password.
[It should be compatible with ssl alpn](https://docs.aws.amazon.com/iot/latest/developerguide/custom-auth.html).
for that this pr add the ssl alpn setting functionality.

* I refered to [GCDAsyncSocket.m](https://opensource.apple.com/source/HTTPServer/HTTPServer-11/CocoaHTTPServer/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m.auto.html), [aws-sdk-ios](https://github.com/aws-amplify/aws-sdk-ios/blob/main/AWSIoT/Internal/AWSIoTMQTTClient.m#L357) ,when implementing
* related: https://github.com/emqx/CocoaMQTT/issues/471