### PR TITLE
Adding some helper methods

### DIFF
--- a/Source/CocoaMQTT5Message.swift
+++ b/Source/CocoaMQTT5Message.swift
@@ -130,6 +130,14 @@ public class CocoaMQTT5Message: NSObject {
         self.qos = qos
         self.retained = retained
     }
+    
+    public init(topic: String, payload: [String: Any], qos: CocoaMQTTQoS = .qos1, retained: Bool = false) throws {
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        self.topic = topic
+        self.payload = [UInt8](data)
+        self.qos = qos
+        self.retained = retained
+    }
 }
 
 extension CocoaMQTT5Message {

--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -166,4 +166,8 @@ extension UInt32 {
     }
 }
 
-
+extension Dictionary where Key == String, Value == String {
+    var userPropertyBytes: [UInt8] {
+        return reduce([UInt8](), { $0 + getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: $1.key.bytesWithLength + $1.value.bytesWithLength) })
+    }
+}

--- a/Source/FrameDisconnect.swift
+++ b/Source/FrameDisconnect.swift
@@ -73,9 +73,7 @@ extension FrameDisconnect {
         }
         //3.14.2.2.4 User Property
         if let userProperty = self.userProperties {
-            for (key, value) in userProperty {
-                properties += getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: key.bytesWithLength + value.bytesWithLength)
-            }
+            properties += userProperty.userPropertyBytes
         }
         //3.14.2.2.5 Server Reference
         if let serverReference = self.serverReference {

--- a/Source/FramePubAck.swift
+++ b/Source/FramePubAck.swift
@@ -77,9 +77,7 @@ extension FramePubAck {
 
         //3.4.2.2.3 User Property
         if let userProperty = self.userProperties {
-            for (key, value) in userProperty {
-                properties += getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: key.bytesWithLength + value.bytesWithLength)
-            }
+            properties += userProperty.userPropertyBytes
         }
 
         return properties;

--- a/Source/FramePubComp.swift
+++ b/Source/FramePubComp.swift
@@ -79,9 +79,7 @@ extension FramePubComp {
 
         //3.7.2.2.3 User Property
         if let userProperty = self.userProperties {
-            for (key, value) in userProperty {
-                properties += getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: key.bytesWithLength + value.bytesWithLength)
-            }
+            properties += userProperty.userPropertyBytes
         }
 
         return properties;

--- a/Source/FramePubRec.swift
+++ b/Source/FramePubRec.swift
@@ -78,9 +78,7 @@ extension FramePubRec {
 
         //3.5.2.2.3 User Property
         if let userProperty = self.userProperties {
-            for (key, value) in userProperty {
-                properties += getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: key.bytesWithLength + value.bytesWithLength)
-            }
+            properties += userProperty.userPropertyBytes
         }
 
         return properties;

--- a/Source/FramePubRel.swift
+++ b/Source/FramePubRel.swift
@@ -75,9 +75,7 @@ extension FramePubRel {
 
         //3.6.2.2.3 User Property
         if let userProperty = self.userProperties {
-            for (key, value) in userProperty {
-                properties += getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: key.bytesWithLength + value.bytesWithLength)
-            }
+            properties += userProperty.userPropertyBytes
         }
 
         return properties;

--- a/Source/MqttAuthProperties.swift
+++ b/Source/MqttAuthProperties.swift
@@ -36,9 +36,7 @@ public class MqttAuthProperties: NSObject {
         }
         //3.15.2.2.5 User Property
         if let userProperty = self.userProperties {
-            for (key, value) in userProperty {
-                properties += getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: key.bytesWithLength + value.bytesWithLength)
-            }
+            properties += userProperty.userPropertyBytes
         }
         
         

--- a/Source/MqttConnectProperties.swift
+++ b/Source/MqttConnectProperties.swift
@@ -64,9 +64,7 @@ public class MqttConnectProperties: NSObject {
         }
         // 3.1.2.11.8 User Property
         if let userProperty = self.userProperties {
-            for (key, value) in userProperty {
-                properties += getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: key.bytesWithLength + value.bytesWithLength)
-            }
+            properties += userProperty.userPropertyBytes
         }
         // 3.1.2.11.9 Authentication Method
         if let authenticationMethod = self.authenticationMethod {

--- a/Source/MqttPublishProperties.swift
+++ b/Source/MqttPublishProperties.swift
@@ -51,6 +51,28 @@ public class MqttPublishProperties: NSObject {
         self.subscriptionIdentifier = subscriptionIdentifier
         self.contentType = contentType
     }
+    
+    public init(
+        propertyLength: Int? = nil,
+        payloadFormatIndicator: PayloadFormatIndicator? = nil,
+        messageExpiryInterval: UInt32? = nil,
+        topicAlias: UInt16? = nil,
+        responseTopic: String? = nil,
+        correlation: String? = nil,
+        userProperty: [String: String]? = nil,
+        subscriptionIdentifier: UInt32? = nil,
+        contentType: String? = nil
+    ) {
+        self.propertyLength = propertyLength
+        self.payloadFormatIndicator = payloadFormatIndicator
+        self.messageExpiryInterval = messageExpiryInterval
+        self.topicAlias = topicAlias
+        self.responseTopic = responseTopic
+        self.correlationData = correlation?.bytesWithLength
+        self.userProperty = userProperty
+        self.subscriptionIdentifier = subscriptionIdentifier
+        self.contentType = contentType
+    }
 
     public var properties: [UInt8] {
         var properties = [UInt8]()


### PR DESCRIPTION
1. Some APIs are encapsulated within the framework, which makes it inconvenient for users to call certain APIs, such as `bytesWithLength`.
2. Extracting common code segments helps avoid potential issues caused by repetitive code and ensures consistency.