### PR TITLE
Make subscriptions, subscriptionsWaitingAck and unsubscriptionsWaitin…

### DIFF
--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -49,7 +49,7 @@ import MqttCocoaAsyncSocket
     func mqtt5(_ mqtt5: CocoaMQTT5, didSubscribeTopics success: NSDictionary, failed: [String], subAckData: MqttDecodeSubAck?)
 
     ///
-    func mqtt5(_ mqtt5: CocoaMQTT5, didUnsubscribeTopics topics: [String], UnsubAckData: MqttDecodeUnsubAck?)
+    func mqtt5(_ mqtt5: CocoaMQTT5, didUnsubscribeTopics topics: [String], unsubAckData: MqttDecodeUnsubAck?)
     
     ///
     func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveDisconnectReasonCode reasonCode: CocoaMQTTDISCONNECTReasonCode)
@@ -849,7 +849,7 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
             _ = subscriptions.removeValue(forKey: t.topic)
         }
 
-        delegate?.mqtt5(self, didUnsubscribeTopics: removeTopics, UnsubAckData: unsuback.unSubAckProperties ?? nil)
+        delegate?.mqtt5(self, didUnsubscribeTopics: removeTopics, unsubAckData: unsuback.unSubAckProperties ?? nil)
         didUnsubscribeTopics(self, removeTopics, unsuback.unSubAckProperties ?? nil)
     }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -49,7 +49,7 @@ import MqttCocoaAsyncSocket
     func mqtt5(_ mqtt5: CocoaMQTT5, didSubscribeTopics success: NSDictionary, failed: [String], subAckData: MqttDecodeSubAck?)
 
     ///
-    func mqtt5(_ mqtt5: CocoaMQTT5, didUnsubscribeTopics topics: [String], unsubAckData: MqttDecodeUnsubAck?)
+    func mqtt5(_ mqtt5: CocoaMQTT5, didUnsubscribeTopics topics: [String], UnsubAckData: MqttDecodeUnsubAck?)
     
     ///
     func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveDisconnectReasonCode reasonCode: CocoaMQTTDISCONNECTReasonCode)
@@ -267,10 +267,10 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     }
 
     /// The subscribed topics in current communication
-    public var subscriptions: [String: CocoaMQTTQoS] = [:]
+    public var subscriptions = ThreadSafeDictionary<String, CocoaMQTTQoS>(label: "subscriptions")
 
-    fileprivate var subscriptionsWaitingAck: [UInt16: [MqttSubscription]] = [:]
-    fileprivate var unsubscriptionsWaitingAck: [UInt16: [MqttSubscription]] = [:]
+    fileprivate var subscriptionsWaitingAck = ThreadSafeDictionary<UInt16, [MqttSubscription]>(label: "subscriptionsWaitingAck")
+    fileprivate var unsubscriptionsWaitingAck = ThreadSafeDictionary<UInt16, [MqttSubscription]>(label: "unsubscriptionsWaitingAck")
 
 
     /// Sending messages
@@ -846,10 +846,10 @@ extension CocoaMQTT5: CocoaMQTTReaderDelegate {
         var removeTopics : [String] = []
         for t in topics {
             removeTopics.append(t.topic)
-            subscriptions.removeValue(forKey: t.topic)
+            _ = subscriptions.removeValue(forKey: t.topic)
         }
 
-        delegate?.mqtt5(self, didUnsubscribeTopics: removeTopics, unsubAckData: unsuback.unSubAckProperties ?? nil)
+        delegate?.mqtt5(self, didUnsubscribeTopics: removeTopics, UnsubAckData: unsuback.unSubAckProperties ?? nil)
         didUnsubscribeTopics(self, removeTopics, unsuback.unSubAckProperties ?? nil)
     }
 

--- a/Source/ThreadSafeDictionary.swift
+++ b/Source/ThreadSafeDictionary.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2022 Kindred Group. All rights reserved.
+// Copyright © 2022. All rights reserved.
 //
 
 import Foundation

--- a/Source/ThreadSafeDictionary.swift
+++ b/Source/ThreadSafeDictionary.swift
@@ -1,0 +1,66 @@
+//
+// Copyright © 2022 Kindred Group. All rights reserved.
+//
+
+import Foundation
+
+
+/// A thread-safe dictionary
+public class ThreadSafeDictionary<K: Hashable,V>: Collection {
+    private var dictionary: [K: V]
+    private let concurrentQueue: DispatchQueue
+
+    public var startIndex: Dictionary<K, V>.Index {
+        self.concurrentQueue.sync {
+            return self.dictionary.startIndex
+        }
+    }
+
+    public var endIndex: Dictionary<K, V>.Index {
+        self.concurrentQueue.sync {
+            return self.dictionary.endIndex
+        }
+    }
+
+    public init(label: String, dict: [K: V] = [K:V]()) {
+        self.dictionary = dict
+        concurrentQueue = DispatchQueue(label: label, attributes: .concurrent)
+    }
+
+    public func index(after i: Dictionary<K, V>.Index) -> Dictionary<K, V>.Index {
+        concurrentQueue.sync {
+            self.dictionary.index(after: i)
+        }
+    }
+
+    subscript(key: K) -> V? {
+        set(newValue) {
+            concurrentQueue.async(flags: .barrier) {[weak self] in
+                self?.dictionary[key] = newValue
+            }
+        }
+        get {
+            concurrentQueue.sync {
+                self.dictionary[key]
+            }
+        }
+    }
+
+    public subscript(index: Dictionary<K, V>.Index) -> Dictionary<K, V>.Element {
+        concurrentQueue.sync {
+            self.dictionary[index]
+        }
+    }
+    
+    public func removeValue(forKey key: K) -> V? {
+        concurrentQueue.sync(flags: .barrier) {
+            self.dictionary.removeValue(forKey: key)
+        }
+    }
+
+    public func removeAll() {
+        concurrentQueue.async(flags: .barrier) {[weak self] in
+            self?.dictionary.removeAll()
+        }
+    }
+}


### PR DESCRIPTION
The subscriptions, subscriptionsWaitingAck and unsubscriptionsWaitingAck are not thread safe. 
I created a `ThreadSafeDictionary` to make them thread safe.
```
    public var subscriptions: [String: CocoaMQTTQoS] = [:]

    fileprivate var subscriptionsWaitingAck: [UInt16: [MqttSubscription]] = [:]
    fileprivate var unsubscriptionsWaitingAck: [UInt16: [MqttSubscription]] = [:]
```