### PR TITLE
Make subscriptions, subscriptionsWaitingAck and unsubscriptionsWaitin…

### DIFF
--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -267,10 +267,10 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     }
 
     /// The subscribed topics in current communication
-    public var subscriptions: [String: CocoaMQTTQoS] = [:]
+    public var subscriptions = ThreadSafeDictionary<String, CocoaMQTTQoS>(label: "subscriptions")
 
-    fileprivate var subscriptionsWaitingAck: [UInt16: [MqttSubscription]] = [:]
-    fileprivate var unsubscriptionsWaitingAck: [UInt16: [MqttSubscription]] = [:]
+    fileprivate var subscriptionsWaitingAck = ThreadSafeDictionary<UInt16, [MqttSubscription]>(label: "subscriptionsWaitingAck")
+    fileprivate var unsubscriptionsWaitingAck = ThreadSafeDictionary<UInt16, [MqttSubscription]>(label: "unsubscriptionsWaitingAck")
 
 
     /// Sending messages

--- a/Source/ThreadSafeDictionary.swift
+++ b/Source/ThreadSafeDictionary.swift
@@ -1,0 +1,67 @@
+//
+// Copyright © 2022. All rights reserved.
+//
+
+import Foundation
+
+
+/// A thread-safe dictionary
+public class ThreadSafeDictionary<K: Hashable,V>: Collection {
+    private var dictionary: [K: V]
+    private let concurrentQueue: DispatchQueue
+
+    public var startIndex: Dictionary<K, V>.Index {
+        self.concurrentQueue.sync {
+            return self.dictionary.startIndex
+        }
+    }
+
+    public var endIndex: Dictionary<K, V>.Index {
+        self.concurrentQueue.sync {
+            return self.dictionary.endIndex
+        }
+    }
+
+    public init(label: String, dict: [K: V] = [K:V]()) {
+        self.dictionary = dict
+        concurrentQueue = DispatchQueue(label: label, attributes: .concurrent)
+    }
+
+    public func index(after i: Dictionary<K, V>.Index) -> Dictionary<K, V>.Index {
+        concurrentQueue.sync {
+            self.dictionary.index(after: i)
+        }
+    }
+
+    public subscript(key: K) -> V? {
+        set(newValue) {
+            concurrentQueue.async(flags: .barrier) {[weak self] in
+                self?.dictionary[key] = newValue
+            }
+        }
+        get {
+            concurrentQueue.sync {
+                self.dictionary[key]
+            }
+        }
+    }
+
+    public subscript(index: Dictionary<K, V>.Index) -> Dictionary<K, V>.Element {
+        concurrentQueue.sync {
+            self.dictionary[index]
+        }
+    }
+    
+    @discardableResult
+    public func removeValue(forKey key: K) -> V? {
+        concurrentQueue.sync(flags: .barrier) {
+            self.dictionary.removeValue(forKey: key)
+        }
+    }
+
+    public func removeAll() {
+        concurrentQueue.async(flags: .barrier) {[weak self] in
+            self?.dictionary.removeAll()
+        }
+    }
+}

--- a/Source/ThreadSafeDictionary.swift
+++ b/Source/ThreadSafeDictionary.swift
@@ -11,13 +11,13 @@ public class ThreadSafeDictionary<K: Hashable,V>: Collection {
     private let concurrentQueue: DispatchQueue
 
     public var startIndex: Dictionary<K, V>.Index {
-        self.concurrentQueue.sync {
+        concurrentQueue.sync {
             return self.dictionary.startIndex
         }
     }
 
     public var endIndex: Dictionary<K, V>.Index {
-        self.concurrentQueue.sync {
+        concurrentQueue.sync {
             return self.dictionary.endIndex
         }
     }


### PR DESCRIPTION
The subscriptions, subscriptionsWaitingAck and unsubscriptionsWaitingAck are not thread safe.
I created a ThreadSafeDictionary to make them thread safe.

```
    public var subscriptions: [String: CocoaMQTTQoS] = [:]

    fileprivate var subscriptionsWaitingAck: [UInt16: [MqttSubscription]] = [:]
    fileprivate var unsubscriptionsWaitingAck: [UInt16: [MqttSubscription]] = [:]
```