### PR TITLE
Bugfix: Publishing a message: userProperty key is ignored, causing connection termination

### DIFF
--- a/Source/MqttPublishProperties.swift
+++ b/Source/MqttPublishProperties.swift
@@ -77,9 +77,8 @@ public class MqttPublishProperties: NSObject {
         }
         //3.3.2.3.7 Property Length User Property
         if let userProperty = self.userProperty {
-            let dictValues = [String](userProperty.values)
-            for (value) in dictValues {
-                properties += getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: value.bytesWithLength)
+            for (key, value) in userProperty {
+                properties += getMQTTPropertyData(type: CocoaMQTTPropertyName.userProperty.rawValue, value: key.bytesWithLength + value.bytesWithLength)
             }
         }
         //3.3.2.3.8 Subscription Identifier


### PR DESCRIPTION
When publishing a message with user properties, keys of those properties are ignored. This is causing issues (tested with emqx/emqx:5.3.0), the broker terminates the connection.

Code to reproduce the issue:
```swift
// Connect to your MQTT 5 broker first...

// Then publish a message with user properties
let props = MqttPublishProperties()
props.userProperty = ["test":"userprop", "test2": "userprop2"]
mqtt5.publish("chat/test", withString: "id:123", properties: props)
```

Error logs:
```
didPublishMessage: CocoaMQTT5Message(topic: chat/test, qos: qos0, payload: [105, 100, 58, 49, 50, 51])
didDisconnect: Optional(Error Domain=MGCDAsyncSocketErrorDomain Code=7 "Socket closed by remote peer" UserInfo={NSLocalizedDescription=Socket closed by remote peer})
```

I found that both the key.bytesWithLength and value.bytesWithLength need to be concatenated.

I tested the fix against emqx/emqx:5.3.0.

Thanks 😊