### PR TITLE
bumping cocoapods dependency on starscream to 4.0.8

### DIFF
--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   
   s.subspec 'WebSockets' do |ss|
     ss.dependency "CocoaMQTT/Core"
-    ss.dependency "Starscream", "4.0.4"
+    ss.dependency "Starscream", "4.0.8"
     ss.source_files = "Source/CocoaMQTTWebSocket.swift"
   end
 end


### PR DESCRIPTION
Starscream was already bumped in the Cartfile and the Package.swift, this PR bumps it also for CocoaPods to 4.0.8