### PR TITLE
Update CocoaMQTT.swift for make properties thread safe

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -264,10 +264,10 @@ public class CocoaMQTT: NSObject, CocoaMQTTClient {
     }
     
     /// The subscribed topics in current communication
-    public var subscriptions: [String: CocoaMQTTQoS] = [:]
+    public var subscriptions = ThreadSafeDictionary<String, CocoaMQTTQoS>(label: "subscriptions")
     
-    fileprivate var subscriptionsWaitingAck: [UInt16: [(String, CocoaMQTTQoS)]] = [:]
-    fileprivate var unsubscriptionsWaitingAck: [UInt16: [String]] = [:]
+    fileprivate var subscriptionsWaitingAck = ThreadSafeDictionary<UInt16, [(String, CocoaMQTTQoS)]>(label: "subscriptionsWaitingAck")
+    fileprivate var unsubscriptionsWaitingAck = ThreadSafeDictionary<UInt16, [String]>(label: "unsubscriptionsWaitingAck")
     
 
     /// Sending messages


### PR DESCRIPTION
In CocoaMQTT.swift, these properties below are not thread safe, this is similar with [#543](https://github.com/emqx/CocoaMQTT/pull/543)
I use ThreadSafeDictionary make them thread safe.

```
    public var subscriptions: [String: CocoaMQTTQoS] = [:]

    fileprivate var subscriptionsWaitingAck: [UInt16: [(String, CocoaMQTTQoS)]] = [:]
    fileprivate var unsubscriptionsWaitingAck: [UInt16: [String]] = [:] 
```