### PR TITLE
Fix protocol conformance due to Starscream 4.0.X update

### DIFF
--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -457,7 +457,7 @@ extension CocoaMQTTWebSocket.StarscreamConnection: CertificatePinning {
 }
 
 extension CocoaMQTTWebSocket.StarscreamConnection: WebSocketDelegate {
-    public func didReceive(event: Starscream.WebSocketEvent, client: any Starscream.WebSocketClient) {
+    public func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocket) {
         switch event {
         case .connected(_):
             delegate?.connectionOpened(self)


### PR DESCRIPTION
This small PR updates the protocol conformance to align with the changes introduced in Starscream 4.0.X.

**Why this is needed**
The outdated Starscream version violates Apple’s new privacy requirements, making the library unusable via CocoaPods. Specifically, apps using the current version receive the following App Store rejection:

> ITMS-91061: Missing privacy manifest – Your app includes Frameworks/Starscream.framework/Starscream, which includes Starscream, an SDK identified as a commonly used third-party SDK. As per Apple’s new policy, such SDKs must include a privacy manifest file. Please update to a version of the SDK that includes this file. More details: [Apple’s third-party SDK requirements](https://developer.apple.com/support/third-party-SDK-requirements).

**Request**
Please accept this PR and release version 2.0.8 to CocoaPods to restore compatibility.

Thanks a lot!