### PR TITLE
fixed error with CocoaMQTTWebSocket.StarscreamConnection does not con…

### DIFF
--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -457,7 +457,7 @@ extension CocoaMQTTWebSocket.StarscreamConnection: CertificatePinning {
 }
 
 extension CocoaMQTTWebSocket.StarscreamConnection: WebSocketDelegate {
-    public func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocket) {
+    public func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocketClient) {
         switch event {
         case .connected(_):
             delegate?.connectionOpened(self)


### PR DESCRIPTION
Previously when building the project there would be the error
Type 'CocoaMQTTWebSocket.StarscreamConnection' does not conform to protocol 'WebSocketDelegate'
This was caused because CocoaMQTTWebSocket.StarscreamConnection is supposed to conform to WebSocketDelegate protocol.
Which requires it to implement the method 
```swift
func didReceive(event: WebSocketEvent, client: WebSocketClient)
```
However CocoaMQTTWebSocket.StarscreamConnection is not implementing the protocol correctly
```swift
extension CocoaMQTTWebSocket.StarscreamConnection: WebSocketDelegate {
    public func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocket) {
```
using Starscream.WebSocket instead of Starscream.WebSocketClient

#621 