### PR TITLE
fix: honor WebSocket connect timeout

### DIFF
--- a/CocoaMQTTTests/GracefulDisconnectTests.swift
+++ b/CocoaMQTTTests/GracefulDisconnectTests.swift
@@ -309,10 +309,10 @@ final class GracefulDisconnectTests: XCTestCase {
         let callbackQueue = DispatchQueue(label: "tests.graceful-disconnect.connect-timeout-callbacks")
         let disconnected = expectation(description: "pending connection timed out")
         delegate.onDisconnect = { error in
-            XCTAssertTrue(
-                error is CocoaMQTTConnectTimeoutError,
-                "Expected CocoaMQTTConnectTimeoutError, got \(String(describing: error))"
-            )
+            guard let mqttError = error as? CocoaMQTTError,
+                  case .connectTimeout = mqttError else {
+                return XCTFail("Expected CocoaMQTTError.connectTimeout, got \(String(describing: error))")
+            }
             disconnected.fulfill()
         }
         websocket.setDelegate(delegate, delegateQueue: callbackQueue)

--- a/CocoaMQTTTests/GracefulDisconnectTests.swift
+++ b/CocoaMQTTTests/GracefulDisconnectTests.swift
@@ -309,10 +309,10 @@ final class GracefulDisconnectTests: XCTestCase {
         let callbackQueue = DispatchQueue(label: "tests.graceful-disconnect.connect-timeout-callbacks")
         let disconnected = expectation(description: "pending connection timed out")
         delegate.onDisconnect = { error in
-            guard let mqttError = error as? CocoaMQTTError,
-                  case .connectTimeout = mqttError else {
-                return XCTFail("Expected connectTimeout, got \(String(describing: error))")
-            }
+            XCTAssertTrue(
+                error is CocoaMQTTConnectTimeoutError,
+                "Expected CocoaMQTTConnectTimeoutError, got \(String(describing: error))"
+            )
             disconnected.fulfill()
         }
         websocket.setDelegate(delegate, delegateQueue: callbackQueue)

--- a/CocoaMQTTTests/GracefulDisconnectTests.swift
+++ b/CocoaMQTTTests/GracefulDisconnectTests.swift
@@ -86,12 +86,15 @@ final class GracefulDisconnectTests: XCTestCase {
     private final class WebSocketConnection: NSObject, CocoaMQTTWebSocketConnection {
         weak var delegate: CocoaMQTTWebSocketConnectionDelegate?
         var queue = DispatchQueue(label: "tests.graceful-disconnect.websocket")
+        var onConnect: (() -> Void)?
         var onWrite: (() -> Void)?
         var onDisconnect: (() -> Void)?
         private var completions = [(Error?) -> Void]()
         private var events = [String]()
 
-        func connect() {}
+        func connect() {
+            onConnect?()
+        }
 
         func disconnect() {
             events.append("disconnect")
@@ -294,6 +297,97 @@ final class GracefulDisconnectTests: XCTestCase {
 
         wait(for: [writeQueued, disconnected], timeout: 1)
         XCTAssertEqual(connection.snapshot().last, "disconnect")
+    }
+
+    func testWebSocketConnectTimeoutClosesPendingConnection() throws {
+        let connection = WebSocketConnection()
+        let websocket = CocoaMQTTWebSocket(
+            uri: "/mqtt",
+            builder: WebSocketBuilder(connection: connection)
+        )
+        let delegate = SocketDelegate()
+        let callbackQueue = DispatchQueue(label: "tests.graceful-disconnect.connect-timeout-callbacks")
+        let disconnected = expectation(description: "pending connection timed out")
+        delegate.onDisconnect = { error in
+            guard let mqttError = error as? CocoaMQTTError,
+                  case .connectTimeout = mqttError else {
+                return XCTFail("Expected connectTimeout, got \(String(describing: error))")
+            }
+            disconnected.fulfill()
+        }
+        websocket.setDelegate(delegate, delegateQueue: callbackQueue)
+
+        try websocket.connect(toHost: "localhost", onPort: 8083, withTimeout: 0.01)
+
+        wait(for: [disconnected], timeout: 1)
+        XCTAssertEqual(connection.snapshot().last, "disconnect")
+    }
+
+    func testWebSocketConnectTimeoutIsCancelledAfterConnectionOpens() throws {
+        let connection = WebSocketConnection()
+        let websocket = CocoaMQTTWebSocket(
+            uri: "/mqtt",
+            builder: WebSocketBuilder(connection: connection)
+        )
+        let opened = expectation(description: "connection opened")
+        let notDisconnected = expectation(description: "opened connection remains connected")
+        notDisconnected.isInverted = true
+        connection.onConnect = { [weak connection] in
+            guard let connection = connection else { return }
+            connection.delegate?.connectionOpened(connection)
+            opened.fulfill()
+        }
+        connection.onDisconnect = {
+            notDisconnected.fulfill()
+        }
+
+        try websocket.connect(toHost: "localhost", onPort: 8083, withTimeout: 0.01)
+
+        wait(for: [opened, notDisconnected], timeout: 0.1)
+    }
+
+    func testWebSocketReconnectDoesNotApplyStaleTimeoutToReusedConnection() throws {
+        let connection = WebSocketConnection()
+        let websocket = CocoaMQTTWebSocket(
+            uri: "/mqtt",
+            builder: WebSocketBuilder(connection: connection)
+        )
+        let delegate = SocketDelegate()
+        let callbackQueue = DispatchQueue(label: "tests.graceful-disconnect.stale-connect-timeout-callbacks")
+        let timerBlockStarted = expectation(description: "connect timeout timer blocked")
+        let secondConnectReturned = expectation(description: "second connection attempt returned")
+        let notDisconnected = expectation(description: "reconnected socket remains connected")
+        notDisconnected.isInverted = true
+        let timerBlockGate = DispatchSemaphore(value: 0)
+        var connectCount = 0
+
+        delegate.onDisconnect = { _ in
+            notDisconnected.fulfill()
+        }
+        connection.onConnect = { [weak connection] in
+            connectCount += 1
+            if connectCount == 2, let connection = connection {
+                connection.delegate?.connectionOpened(connection)
+            }
+        }
+        websocket.setDelegate(delegate, delegateQueue: callbackQueue)
+        try websocket.connect(toHost: "localhost", onPort: 8083, withTimeout: 0.01)
+
+        websocket.internalQueue.async {
+            timerBlockStarted.fulfill()
+            timerBlockGate.wait()
+        }
+        wait(for: [timerBlockStarted], timeout: 1)
+
+        DispatchQueue.global().async {
+            try? websocket.connect(toHost: "localhost", onPort: 8083, withTimeout: 1)
+            secondConnectReturned.fulfill()
+        }
+
+        usleep(100_000)
+        timerBlockGate.signal()
+        wait(for: [secondConnectReturned], timeout: 1)
+        wait(for: [notDisconnected], timeout: 0.1)
     }
 
     func testWebSocketIncompletePayloadTriggersReadTimeout() throws {

--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -76,13 +76,9 @@ extension UInt8 {
     }
 }
 
-/// Error reported when a WebSocket connection does not open before its timeout.
-public struct CocoaMQTTConnectTimeoutError: Error {
-    public init() {}
-}
-
 public enum CocoaMQTTError: Error {
     case invalidURL
+    case connectTimeout
     case readTimeout
     case writeTimeout
     @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -78,6 +78,7 @@ extension UInt8 {
 
 public enum CocoaMQTTError: Error {
     case invalidURL
+    case connectTimeout
     case readTimeout
     case writeTimeout
     @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Source/CocoaMQTTTypes.swift
+++ b/Source/CocoaMQTTTypes.swift
@@ -76,9 +76,13 @@ extension UInt8 {
     }
 }
 
+/// Error reported when a WebSocket connection does not open before its timeout.
+public struct CocoaMQTTConnectTimeoutError: Error {
+    public init() {}
+}
+
 public enum CocoaMQTTError: Error {
     case invalidURL
-    case connectTimeout
     case readTimeout
     case writeTimeout
     @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -173,7 +173,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
                           self.connectGeneration == connectGeneration,
                           let currentConnection = self.connection,
                           currentConnection.isEqual(newConnection) else { return }
-                    self.closeConnection(withError: CocoaMQTTError.connectTimeout)
+                    self.closeConnection(withError: CocoaMQTTConnectTimeoutError())
                 }
             }
             newConnection.connect()

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -166,6 +166,16 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
             connection = newConnection
             newConnection.delegate = self
             newConnection.queue = internalQueue
+            let connectGeneration = self.connectGeneration
+            if timeout > 0 {
+                connectTimeoutTimer.schedule(wallDeadline: .now() + timeout) { [weak self, newConnection] in
+                    guard let self = self,
+                          self.connectGeneration == connectGeneration,
+                          let currentConnection = self.connection,
+                          currentConnection.isEqual(newConnection) else { return }
+                    self.closeConnection(withError: CocoaMQTTError.connectTimeout)
+                }
+            }
             newConnection.connect()
         }
     }
@@ -207,12 +217,16 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
     internal var internalQueue = DispatchQueue(label: "CocoaMQTTWebSocket")
 
     private var connection: CocoaMQTTWebSocketConnection?
+    private var connectGeneration: UInt64 = 0
+    private lazy var connectTimeoutTimer = ReusableTimer(queue: internalQueue)
 
     private func reset() {
+        connectGeneration &+= 1
         connection?.delegate = nil
         connection?.disconnect()
         connection = nil
 
+        connectTimeoutTimer.reset()
         readBuffer.removeAll()
         scheduledReads.removeAll()
         readTimeoutTimer.reset()
@@ -371,6 +385,8 @@ extension CocoaMQTTWebSocket: CocoaMQTTWebSocketConnectionDelegate {
 
     public func connectionOpened(_ conn: CocoaMQTTWebSocketConnection) {
         guard conn.isEqual(connection) else { return }
+        connectGeneration &+= 1
+        connectTimeoutTimer.reset()
         guard let delegate = delegate else { return }
         guard let delegateQueue = delegateQueue else { return }
         delegateQueue.async {

--- a/Source/WebSocket/CocoaMQTTWebSocket.swift
+++ b/Source/WebSocket/CocoaMQTTWebSocket.swift
@@ -173,7 +173,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTDisconnectAfterWritingSocket,
                           self.connectGeneration == connectGeneration,
                           let currentConnection = self.connection,
                           currentConnection.isEqual(newConnection) else { return }
-                    self.closeConnection(withError: CocoaMQTTConnectTimeoutError())
+                    self.closeConnection(withError: CocoaMQTTError.connectTimeout)
                 }
             }
             newConnection.connect()


### PR DESCRIPTION
## Summary
- honor positive `withTimeout` values in `CocoaMQTTWebSocket.connect`
- report `CocoaMQTTError.connectTimeout` when a WebSocket connection does not open in time
- cancel/invalidate timeout state when the connection opens or a new connection attempt starts
- add regression coverage for timeout, successful open, and reused-connection reconnect behavior

Fixes #739

## Scope
This PR targets `release/2.x` and is intended for the 2.3.1 patch release. It does not port the fix to later release lines.

## Verification
- `swift test ... --filter GracefulDisconnectTests.testWebSocketConnectTimeout|GracefulDisconnectTests.testWebSocketReconnectDoesNotApplyStaleTimeoutToReusedConnection`
- non-broker SwiftPM test suite: 290 tests, 0 failures
- `swift build`

The broker-dependent integration suites were excluded because no local broker endpoint was available.