### PR TITLE
release: prepare CocoaMQTT 2.4.1

### DIFF
--- a/.github/api-breakage-allowlist-2.3.txt
+++ b/.github/api-breakage-allowlist-2.3.txt
@@ -1,1 +1,2 @@
 API breakage: typealias ThreadSafeDictionary.Iterator has underlying type change from Swift.IndexingIterator<CocoaMQTT.ThreadSafeDictionary<K, V>> to Swift.Dictionary<K, V>.Iterator
+API breakage: enumelement CocoaMQTTError.connectTimeout has been added as a new enum case

--- a/.github/workflows/lts-compatibility.yml
+++ b/.github/workflows/lts-compatibility.yml
@@ -36,4 +36,5 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           swift package diagnose-api-breaking-changes "${BASE_SHA}" \
-            --products CocoaMQTT CocoaMQTTWebSocket
+            --products CocoaMQTT CocoaMQTTWebSocket \
+            --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt

--- a/.github/workflows/release-2.x.yml
+++ b/.github/workflows/release-2.x.yml
@@ -125,7 +125,8 @@ jobs:
             --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt
           if [ "${PREVIOUS_TAG}" != "2.3.0" ]; then
             swift package diagnose-api-breaking-changes "${PREVIOUS_TAG}" \
-              --products CocoaMQTT CocoaMQTTWebSocket
+              --products CocoaMQTT CocoaMQTTWebSocket \
+              --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt
           fi
 
       - name: Build package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.4.1
+
+Fix WebSocket connection timeouts when `withTimeout` is positive. A pending
+WebSocket connection now closes with `CocoaMQTTError.connectTimeout`, and the
+timeout is invalidated when the connection opens or a new connection attempt
+starts.
+
+Compatibility note:
+
+- This release intentionally adds `CocoaMQTTError.connectTimeout` to the public
+  error enum. Existing exhaustive switches over `CocoaMQTTError` must handle
+  the new case.
+
 ## 2.4.0
 
 CocoaMQTT 2.4.0 is the stable, long-term-maintenance baseline for the 2.x

--- a/CocoaMQTT.podspec
+++ b/CocoaMQTT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "CocoaMQTT"
-  s.version     = "2.4.0"
+  s.version     = "2.4.1"
   s.summary     = "MQTT v3.1.1 client library for iOS and OS X written with Swift 5"
   s.homepage    = "https://github.com/emqx/CocoaMQTT"
   s.license     = { :type => "MIT" }
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "12.0"
   s.tvos.deployment_target = "10.0"
   # s.watchos.deployment_target = "2.0"
-  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.4.0"}
+  s.source   = { :git => "https://github.com/emqx/CocoaMQTT.git", :tag => "2.4.1"}
   s.default_subspec = 'Core'
   
   s.subspec 'Core' do |ss|

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -25,9 +25,12 @@ into `release/2.x`; the branches must not be merged wholesale.
 
 ## Compatibility
 
-Patch releases in this line preserve the 2.4 public API and supported platform
-matrix. CI builds both package products, validates CocoaPods, and checks the
-public API against both 2.3.0 and the pull request base commit.
+Patch releases in this line normally preserve the 2.4 public API and supported
+platform matrix. 2.4.1 is an explicit compatibility exception: it adds
+`CocoaMQTTError.connectTimeout` so WebSocket connect timeouts use the existing
+public error type. CI records this exception in the API breakage allowlist.
+CI builds both package products, validates CocoaPods, and checks the public API
+against both 2.3.0 and the pull request base commit.
 
 Merging a stable version metadata update into `release/2.x` starts the
 `Check CocoaMQTT 2.x Release` workflow. If that version is not already tagged,

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
## Summary
- bump CocoaMQTT release metadata from 2.4.0 to 2.4.1
- document the WebSocket connect-timeout fix and intentional `CocoaMQTTError.connectTimeout` API break
- allow the accepted enum-case breakage in the 2.x API compatibility and release readiness checks

Related: #740

## Verification
- `swift package diagnose-api-breaking-changes 2.3.0 --products CocoaMQTT CocoaMQTTWebSocket --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt`
- `swift package diagnose-api-breaking-changes 2.4.0 --products CocoaMQTT CocoaMQTTWebSocket --breakage-allowlist-path .github/api-breakage-allowlist-2.3.txt`
- release metadata and workflow YAML validation passed